### PR TITLE
Add connection testing & retry logic to pool

### DIFF
--- a/redis/pool.go
+++ b/redis/pool.go
@@ -51,6 +51,14 @@ var errPoolClosed = errors.New("redigo: connection pool closed")
 //                  }
 //                  return c, err
 //              },
+// 				//custom connection test method
+//				Test: func(c redis.Conn) error {
+//					if _, err := c.Do("PING"); err != nil {
+//						log.Printf("Redis Test function caught error %v", err)
+//						return err
+//					}
+//					return nil
+//				},
 //          }
 //
 // This pool has a maximum of three connections to the server specified by the

--- a/redis/pool_test.go
+++ b/redis/pool_test.go
@@ -16,7 +16,6 @@ package redis
 
 import (
 	"io"
-	"log"
 	"testing"
 	"time"
 )
@@ -54,9 +53,7 @@ func TestPoolReuse(t *testing.T) {
 		MaxIdle: 2,
 		Dial:    func() (Conn, error) { open += 1; dialed += 1; return &fakeConn{open: &open}, nil },
 		Test: func(c Conn) error {
-			log.Printf("testing connection %v", c)
 			if _, err := c.Do("PING"); err != nil {
-				log.Printf("Redis Test function caught error %v", err)
 				return err
 			}
 			return nil


### PR DESCRIPTION
Hi Gary, thanks for your excellent redis library.

I was occasionally getting EOF's from Redis, I read that this can potentially happen with persistent connections, so just like most DB pooling libraries, I implemented an optional Test function with MaxRetries.

Sorry for all the little commits while I was testing, I'm still trying to get a reasonable Go workflow down between my git-enabled computer and my vagrant app dev environment.
