### PR TITLE
Fix a bug where redisx didn't actually ignore fields in structs tagged with "-"

### DIFF
--- a/redisx/util.go
+++ b/redisx/util.go
@@ -52,7 +52,10 @@ func compileStructSpec(t reflect.Type, depth map[string]int, index []int, ss *st
 			fs := &fieldSpec{name: f.Name}
 			tag := f.Tag.Get("redis")
 			p := strings.Split(tag, ",")
-			if len(p) > 0 && p[0] != "-" {
+			if len(p) > 0 {
+				if p[0] == "-" {
+					continue
+				}
 				if len(p[0]) > 0 {
 					fs.name = p[0]
 				}


### PR DESCRIPTION
From testing, the ScanStruct function was not actually ignoring fields tagged with redis:"-". This seems to fix this, although I can't say I fully understand what's happening in the bottom half of the loop.
