### PR TITLE
Minor fix for the redis.Strings helper function.  Now properly parses a pipelined reply as a slice of strings.

### DIFF
--- a/redis/reply.go
+++ b/redis/reply.go
@@ -223,7 +223,7 @@ func Strings(reply interface{}, err error) ([]string, error) {
 			if reply[i] == nil {
 				continue
 			}
-			p, ok := reply[i].([]byte)
+			p, ok := reply[i].(string)
 			if !ok {
 				return nil, fmt.Errorf("redigo: unexpected element type for Strings, got type %T", reply[i])
 			}


### PR DESCRIPTION
Please see my Issue which talks about this problem.  I am simply trying to get a slice of strings back from the redis.Strings helper function from a pipelined call that contains a bunch of SET calls to Redis.  Redis returns OK as a result for all the matching SET calls, however I believe this is a legitimate bug where the redis.Strings function will return an empty slice instead of a proper slice that contains all that OK strings within it.
