### PR TITLE
pool: Don't remove idle connections until timeout.

### DIFF
--- a/redis/pool.go
+++ b/redis/pool.go
@@ -229,11 +229,7 @@ func (p *Pool) put(c Conn, forceClose bool) error {
 		p.mu.Lock()
 		if !p.closed {
 			p.idle.PushFront(idleConn{t: nowFunc(), c: c})
-			if p.idle.Len() > p.MaxIdle {
-				c = p.idle.Remove(p.idle.Back()).(idleConn).c
-			} else {
-				c = nil
-			}
+			c = nil
 		}
 		p.mu.Unlock()
 	}


### PR DESCRIPTION
Short version: With this patch pooled connections aren't discarded right as they are put back in to the pool, but rather after they have timed out.

Long version: I found that the connection pool scaled very badly unless I increased the connection pool to have more than a minimum of 50 idle instances. I found the reason for that was that under load redigo would create a huge amount of connections and close them right away.

The root cause was the removed code below, that closes a connection as it is being put back in the pool, if there are more than "MaxIdle" connnections. So instead of closing them as they are being put back in the pool it now relies of the code in "func (p *Pool) get()" that closes idle connections after the idle timeout has expired instead. This allows a moderate number of "maxidle" (like 4), and it will scale very well on sudden bursts.
