### PR TITLE
Fix typo in docs

### DIFF
--- a/redis/pool.go
+++ b/redis/pool.go
@@ -67,7 +67,7 @@ var errPoolClosed = errors.New("redigo: connection pool closed")
 //  )
 //
 //  func main() {
-//      floag.Parse()
+//      flag.Parse()
 //      pool = newPool(*redisServer, *redisPassword)
 //      ...
 //  }


### PR DESCRIPTION
HI, 

I fixed a small typo on the docs so that if people copy and paste the example (like I did) they don't have problems.

Cheers
