### PR TITLE
Without that thing, go 1.3.3 says 'unexpected range'.

### DIFF
--- a/redisx/connmux.go
+++ b/redisx/connmux.go
@@ -134,7 +134,7 @@ func (c *muxConn) Close() error {
 		return nil
 	}
 	c.Flush()
-	for range c.ids {
+	for _ = range c.ids {
 		_, err = c.Receive()
 	}
 	return err


### PR DESCRIPTION
You are working with golang 1.4 beta?

Here is a dummy syntax patch.
