### PR TITLE
Change link to Sentinel lib that supports gomodule/redigo

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -37,7 +37,7 @@ Related Projects
 
 - [rafaeljusto/redigomock](https://godoc.org/github.com/rafaeljusto/redigomock) - A mock library for Redigo.
 - [chasex/redis-go-cluster](https://github.com/chasex/redis-go-cluster) - A Redis cluster client implementation.
-- [FZambia/go-sentinel](https://github.com/FZambia/go-sentinel) - Redis Sentinel support for Redigo
+- [FZambia/sentinel](https://github.com/FZambia/sentinel) - Redis Sentinel support for Redigo
 - [mna/redisc](https://github.com/mna/redisc) - Redis Cluster client built on top of Redigo
 
 Contributing


### PR DESCRIPTION
This is a new package with support of gomodule/redigo, the old package go-sentinel kept untouched to continue working with garyburd/redigo.

I am not happy with this as this increases entropy but I have not found a better way.