### PR TITLE
delete do empty

### DIFF
--- a/redis/log.go
+++ b/redis/log.go
@@ -33,6 +33,7 @@ func NewLoggingConn(conn Conn, logger *log.Logger, prefix string) Conn {
 	return &loggingConn{conn, logger, prefix, nil}
 }
 
+//NewLoggingConnFilter returns a logging wrapper around a connection and a filter function.
 func NewLoggingConnFilter(conn Conn, logger *log.Logger, prefix string, skip func(cmdName string) bool) Conn {
 	if prefix != "" {
 		prefix = prefix + "."

--- a/redis/log.go
+++ b/redis/log.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 )
 
@@ -31,13 +30,21 @@ func NewLoggingConn(conn Conn, logger *log.Logger, prefix string) Conn {
 	if prefix != "" {
 		prefix = prefix + "."
 	}
-	return &loggingConn{conn, logger, prefix}
+	return &loggingConn{conn, logger, prefix, nil}
+}
+
+func NewLoggingConnFilter(conn Conn, logger *log.Logger, prefix string, skip func(cmdName string) bool) Conn {
+	if prefix != "" {
+		prefix = prefix + "."
+	}
+	return &loggingConn{conn, logger, prefix, skip}
 }
 
 type loggingConn struct {
 	Conn
 	logger *log.Logger
 	prefix string
+	skip   func(cmdName string) bool
 }
 
 func (c *loggingConn) Close() error {
@@ -86,7 +93,7 @@ func (c *loggingConn) printValue(buf *bytes.Buffer, v interface{}) {
 }
 
 func (c *loggingConn) print(method, commandName string, args []interface{}, reply interface{}, err error) {
-	if commandName == "" || commandName == strings.ToUpper("ping") {
+	if c.skip != nil && c.skip(commandName) {
 		return
 	}
 	var buf bytes.Buffer

--- a/redis/log.go
+++ b/redis/log.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -85,6 +86,9 @@ func (c *loggingConn) printValue(buf *bytes.Buffer, v interface{}) {
 }
 
 func (c *loggingConn) print(method, commandName string, args []interface{}, reply interface{}, err error) {
+	if commandName == "" || commandName == strings.ToUpper("ping") {
+		return
+	}
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "%s%s(", c.prefix, method)
 	if method != "Receive" {

--- a/redis/pool.go
+++ b/redis/pool.go
@@ -424,7 +424,6 @@ func (ac *activeConn) Close() error {
 			}
 		}
 	}
-	pc.c.Do("")
 	ac.p.put(pc, ac.state != 0 || pc.c.Err() != nil)
 	return nil
 }

--- a/redis/pool.go
+++ b/redis/pool.go
@@ -424,6 +424,7 @@ func (ac *activeConn) Close() error {
 			}
 		}
 	}
+	pc.c.Do("")
 	ac.p.put(pc, ac.state != 0 || pc.c.Err() != nil)
 	return nil
 }


### PR DESCRIPTION
In log mode, output too many 2018/05/10 15:58:24 redis.Do() -> (<nil>, <nil>).
why c.Do("")?