### PR TITLE
Add a stub object for testing redis.Conn

### DIFF
--- a/stubs/conn.go
+++ b/stubs/conn.go
@@ -14,14 +14,14 @@
 
 package stubs
 
-import "fmt"
+import "errors"
 
-// MsgNotImplemented is the default error body returned when a
-// method is invokes without a stub func defined.
-const MsgNotImplemented = "not implemented"
+// ErrNotImplemented is the default error returned when a
+// method is invoked without a stub func defined.
+var ErrNotImplemented = errors.New("stub: not implemented")
 
 // StubConn is a redis.Conn that helps consumers of redigo with testing
-type StubConn struct {
+type Conn struct {
 	OnClose   func() error
 	OnErr     func() error
 	OnDo      func(commandName string, args ...interface{}) (reply interface{}, err error)
@@ -32,54 +32,54 @@ type StubConn struct {
 
 // Close conforms to the redis.Conn interface.
 // "Close closes the connection."
-func (s *StubConn) Close() error {
+func (s *Conn) Close() error {
 	if s.OnClose == nil {
-		return fmt.Errorf(MsgNotImplemented)
+		return ErrNotImplemented
 	}
 	return s.OnClose()
 }
 
 // Err conforms to the redis.Conn interface.
 // "Err returns a non-nil value when the connection is not usable."
-func (s *StubConn) Err() error {
+func (s *Conn) Err() error {
 	if s.OnErr == nil {
-		return fmt.Errorf(MsgNotImplemented)
+		return ErrNotImplemented
 	}
 	return s.OnErr()
 }
 
 // Do conforms to the redis.Conn interface.
 // "Do sends a command to the server and returns the received reply."
-func (s *StubConn) Do(cmd string, args ...interface{}) (reply interface{}, err error) {
+func (s *Conn) Do(cmd string, args ...interface{}) (reply interface{}, err error) {
 	if s.OnDo == nil {
-		return nil, fmt.Errorf(MsgNotImplemented)
+		return nil, ErrNotImplemented
 	}
 	return s.OnDo(cmd, args...)
 }
 
 // Send conforms to the redis.Conn interface.
 // "Send writes the command to the client's output buffer."
-func (s *StubConn) Send(cmd string, args ...interface{}) error {
+func (s *Conn) Send(cmd string, args ...interface{}) error {
 	if s.OnSend == nil {
-		return fmt.Errorf(MsgNotImplemented)
+		return ErrNotImplemented
 	}
 	return s.OnSend(cmd, args...)
 }
 
 // Flush conforms to the redis.Conn interface.
 // "Flush flushes the output buffer to the Redis server."
-func (s *StubConn) Flush() error {
+func (s *Conn) Flush() error {
 	if s.OnFlush == nil {
-		return fmt.Errorf(MsgNotImplemented)
+		return ErrNotImplemented
 	}
 	return s.OnFlush()
 }
 
 // Receive conforms to the redis.Conn interface.
 // "Receive receives a single reply from the Redis server"
-func (s *StubConn) Receive() (reply interface{}, err error) {
+func (s *Conn) Receive() (reply interface{}, err error) {
 	if s.OnReceive == nil {
-		return nil, fmt.Errorf(MsgNotImplemented)
+		return nil, ErrNotImplemented
 	}
 	return s.OnReceive()
 }

--- a/stubs/conn.go
+++ b/stubs/conn.go
@@ -1,0 +1,85 @@
+// Copyright 2012 Gary Burd
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package stubs
+
+import "fmt"
+
+// MsgNotImplemented is the default error body returned when a
+// method is invokes without a stub func defined.
+const MsgNotImplemented = "not implemented"
+
+// StubConn is a redis.Conn that helps consumers of redigo with testing
+type StubConn struct {
+	OnClose   func() error
+	OnErr     func() error
+	OnDo      func(commandName string, args ...interface{}) (reply interface{}, err error)
+	OnSend    func(commandName string, args ...interface{}) error
+	OnFlush   func() error
+	OnReceive func() (reply interface{}, err error)
+}
+
+// Close conforms to the redis.Conn interface.
+// "Close closes the connection."
+func (s *StubConn) Close() error {
+	if s.OnClose == nil {
+		return fmt.Errorf(MsgNotImplemented)
+	}
+	return s.OnClose()
+}
+
+// Err conforms to the redis.Conn interface.
+// "Err returns a non-nil value when the connection is not usable."
+func (s *StubConn) Err() error {
+	if s.OnErr == nil {
+		return fmt.Errorf(MsgNotImplemented)
+	}
+	return s.OnErr()
+}
+
+// Do conforms to the redis.Conn interface.
+// "Do sends a command to the server and returns the received reply."
+func (s *StubConn) Do(cmd string, args ...interface{}) (reply interface{}, err error) {
+	if s.OnDo == nil {
+		return nil, fmt.Errorf(MsgNotImplemented)
+	}
+	return s.OnDo(cmd, args...)
+}
+
+// Send conforms to the redis.Conn interface.
+// "Send writes the command to the client's output buffer."
+func (s *StubConn) Send(cmd string, args ...interface{}) error {
+	if s.OnSend == nil {
+		return fmt.Errorf(MsgNotImplemented)
+	}
+	return s.OnSend(cmd, args...)
+}
+
+// Flush conforms to the redis.Conn interface.
+// "Flush flushes the output buffer to the Redis server."
+func (s *StubConn) Flush() error {
+	if s.OnFlush == nil {
+		return fmt.Errorf(MsgNotImplemented)
+	}
+	return s.OnFlush()
+}
+
+// Receive conforms to the redis.Conn interface.
+// "Receive receives a single reply from the Redis server"
+func (s *StubConn) Receive() (reply interface{}, err error) {
+	if s.OnReceive == nil {
+		return nil, fmt.Errorf(MsgNotImplemented)
+	}
+	return s.OnReceive()
+}

--- a/stubs/conn_test.go
+++ b/stubs/conn_test.go
@@ -1,0 +1,121 @@
+// Copyright 2012 Gary Burd
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package stubs
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+)
+
+func TestStub(t *testing.T) {
+	alt := fmt.Sprintf("alternate message %d", time.Now().UnixNano())
+	testCases := []struct {
+		name string
+		conn redis.Conn
+		xErr string
+	}{
+		{
+			"undefined funcs",
+			&StubConn{},
+			MsgNotImplemented,
+		},
+		{
+			"provided funcs",
+			&StubConn{
+				OnClose: func() error {
+					return fmt.Errorf(alt)
+				},
+				OnErr: func() error {
+					return fmt.Errorf(alt)
+				},
+				OnDo: func(_ string, _ ...interface{}) (interface{}, error) {
+					return nil, fmt.Errorf(alt)
+				},
+				OnSend: func(_ string, _ ...interface{}) error {
+					return fmt.Errorf(alt)
+				},
+				OnFlush: func() error {
+					return fmt.Errorf(alt)
+				},
+				OnReceive: func() (interface{}, error) {
+					return nil, fmt.Errorf(alt)
+				},
+			},
+			alt,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test Close()
+			err := tc.conn.Close()
+			if err == nil {
+				t.Errorf("Close(): expected error\n")
+			}
+			if !strings.Contains(err.Error(), tc.xErr) {
+				t.Errorf("Close(): expected %q; got %q\n", tc.xErr, err.Error())
+			}
+
+			// Test Err()
+			err = tc.conn.Err()
+			if err == nil {
+				t.Errorf("Err(): expected error\n")
+			}
+			if !strings.Contains(err.Error(), tc.xErr) {
+				t.Errorf("Err(): expected %q; got %q\n", tc.xErr, err.Error())
+			}
+
+			// Test Do(...)
+			_, err = tc.conn.Do("SET", "key", "value")
+			if err == nil {
+				t.Errorf("Do(...): expected error\n")
+			}
+			if !strings.Contains(err.Error(), tc.xErr) {
+				t.Errorf("Do(...): expected %q; got %q\n", tc.xErr, err.Error())
+			}
+
+			// Test Send(...)
+			err = tc.conn.Send("SET", "key", "value")
+			if err == nil {
+				t.Errorf("Send(...): expected error\n")
+			}
+			if !strings.Contains(err.Error(), tc.xErr) {
+				t.Errorf("Send(...): expected %q; got %q\n", tc.xErr, err.Error())
+			}
+
+			// Test Flush()
+			err = tc.conn.Flush()
+			if err == nil {
+				t.Errorf("Flush(): expected error\n")
+			}
+			if !strings.Contains(err.Error(), tc.xErr) {
+				t.Errorf("Flush(): expected %q; got %q\n", tc.xErr, err.Error())
+			}
+
+			// Test Receive()
+			_, err = tc.conn.Receive()
+			if err == nil {
+				t.Errorf("Receive(): expected error\n")
+			}
+			if !strings.Contains(err.Error(), tc.xErr) {
+				t.Errorf("Receive(): expected %q; got %q\n", tc.xErr, err.Error())
+			}
+		})
+	}
+}

--- a/stubs/conn_test.go
+++ b/stubs/conn_test.go
@@ -32,12 +32,12 @@ func TestStub(t *testing.T) {
 	}{
 		{
 			"undefined funcs",
-			&StubConn{},
-			MsgNotImplemented,
+			&Conn{},
+			ErrNotImplemented.Error(),
 		},
 		{
 			"provided funcs",
-			&StubConn{
+			&Conn{
 				OnClose: func() error {
 					return fmt.Errorf(alt)
 				},

--- a/stubs/conn_test.go
+++ b/stubs/conn_test.go
@@ -62,60 +62,58 @@ func TestStub(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Test Close()
-			err := tc.conn.Close()
-			if err == nil {
-				t.Errorf("Close(): expected error\n")
-			}
-			if !strings.Contains(err.Error(), tc.xErr) {
-				t.Errorf("Close(): expected %q; got %q\n", tc.xErr, err.Error())
-			}
+		// Test Close()
+		err := tc.conn.Close()
+		if err == nil {
+			t.Errorf("Close(): expected error\n")
+		}
+		if !strings.Contains(err.Error(), tc.xErr) {
+			t.Errorf("Close(): expected %q; got %q\n", tc.xErr, err.Error())
+		}
 
-			// Test Err()
-			err = tc.conn.Err()
-			if err == nil {
-				t.Errorf("Err(): expected error\n")
-			}
-			if !strings.Contains(err.Error(), tc.xErr) {
-				t.Errorf("Err(): expected %q; got %q\n", tc.xErr, err.Error())
-			}
+		// Test Err()
+		err = tc.conn.Err()
+		if err == nil {
+			t.Errorf("Err(): expected error\n")
+		}
+		if !strings.Contains(err.Error(), tc.xErr) {
+			t.Errorf("Err(): expected %q; got %q\n", tc.xErr, err.Error())
+		}
 
-			// Test Do(...)
-			_, err = tc.conn.Do("SET", "key", "value")
-			if err == nil {
-				t.Errorf("Do(...): expected error\n")
-			}
-			if !strings.Contains(err.Error(), tc.xErr) {
-				t.Errorf("Do(...): expected %q; got %q\n", tc.xErr, err.Error())
-			}
+		// Test Do(...)
+		_, err = tc.conn.Do("SET", "key", "value")
+		if err == nil {
+			t.Errorf("Do(...): expected error\n")
+		}
+		if !strings.Contains(err.Error(), tc.xErr) {
+			t.Errorf("Do(...): expected %q; got %q\n", tc.xErr, err.Error())
+		}
 
-			// Test Send(...)
-			err = tc.conn.Send("SET", "key", "value")
-			if err == nil {
-				t.Errorf("Send(...): expected error\n")
-			}
-			if !strings.Contains(err.Error(), tc.xErr) {
-				t.Errorf("Send(...): expected %q; got %q\n", tc.xErr, err.Error())
-			}
+		// Test Send(...)
+		err = tc.conn.Send("SET", "key", "value")
+		if err == nil {
+			t.Errorf("Send(...): expected error\n")
+		}
+		if !strings.Contains(err.Error(), tc.xErr) {
+			t.Errorf("Send(...): expected %q; got %q\n", tc.xErr, err.Error())
+		}
 
-			// Test Flush()
-			err = tc.conn.Flush()
-			if err == nil {
-				t.Errorf("Flush(): expected error\n")
-			}
-			if !strings.Contains(err.Error(), tc.xErr) {
-				t.Errorf("Flush(): expected %q; got %q\n", tc.xErr, err.Error())
-			}
+		// Test Flush()
+		err = tc.conn.Flush()
+		if err == nil {
+			t.Errorf("Flush(): expected error\n")
+		}
+		if !strings.Contains(err.Error(), tc.xErr) {
+			t.Errorf("Flush(): expected %q; got %q\n", tc.xErr, err.Error())
+		}
 
-			// Test Receive()
-			_, err = tc.conn.Receive()
-			if err == nil {
-				t.Errorf("Receive(): expected error\n")
-			}
-			if !strings.Contains(err.Error(), tc.xErr) {
-				t.Errorf("Receive(): expected %q; got %q\n", tc.xErr, err.Error())
-			}
-		})
+		// Test Receive()
+		_, err = tc.conn.Receive()
+		if err == nil {
+			t.Errorf("Receive(): expected error\n")
+		}
+		if !strings.Contains(err.Error(), tc.xErr) {
+			t.Errorf("Receive(): expected %q; got %q\n", tc.xErr, err.Error())
+		}
 	}
 }

--- a/stubs/doc.go
+++ b/stubs/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2012 Gary Burd
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// Package stubs provides testing helpers for consumers of redigo
+package stubs // import "github.com/gomodule/redigo/stubs"


### PR DESCRIPTION
I frequently find myself wanting a helper for testing that I got an abstract `redis.Conn`. (Especially when trying to  abstract away the distinctions between `redigo` and `redisc`.)

I thought others might also benefit from this work.