### PR TITLE
Improve tests suite for nil pointer struct scans

### DIFF
--- a/redis/scan_test.go
+++ b/redis/scan_test.go
@@ -223,6 +223,10 @@ var scanStructTests = []struct {
 			Sdp: &durationScan{Duration: time.Minute},
 		},
 	},
+	{"absent values",
+		[]string{},
+		&s1{},
+	},
 }
 
 func TestScanStruct(t *testing.T) {
@@ -416,17 +420,11 @@ var argsTests = []struct {
 	},
 	{"struct omitempty",
 		redis.Args{}.AddFlat(&struct {
-			I  int               `redis:"i,omitempty"`
-			U  uint              `redis:"u,omitempty"`
-			S  string            `redis:"s,omitempty"`
-			P  []byte            `redis:"p,omitempty"`
-			M  map[string]string `redis:"m,omitempty"`
-			Bt bool              `redis:"Bt,omitempty"`
-			Bf bool              `redis:"Bf,omitempty"`
+			Sdp *durationArg `redis:"Sdp,omitempty"`
 		}{
-			0, 0, "", []byte{}, map[string]string{}, true, false,
+			nil,
 		}),
-		redis.Args{"Bt", true},
+		redis.Args{},
 	},
 }
 


### PR DESCRIPTION
When scanning structs, the test suite wasn't properly verifying that
a pointer field should be nil if the redis field doesn't exist.