### PR TITLE
get idle conn from back in order to rebalance connections

### DIFF
--- a/redis/pool.go
+++ b/redis/pool.go
@@ -301,9 +301,9 @@ func (p *Pool) get(ctx interface {
 	}
 
 	// Get idle connection from the front of idle list.
-	for p.idle.front != nil {
-		pc := p.idle.front
-		p.idle.popFront()
+	for p.idle.back != nil {
+		pc := p.idle.back
+		p.idle.popBack()
 		p.mu.Unlock()
 		if (p.TestOnBorrow == nil || p.TestOnBorrow(pc.c, pc.t) == nil) &&
 			(p.MaxConnLifetime == 0 || nowFunc().Sub(pc.created) < p.MaxConnLifetime) {


### PR DESCRIPTION
When I use this lib for request a VIP:VPORT (LVS) , I found the real servers after LVS  will accept a different number of requests. Such as( the last column num means  this connection was been used times, and the other columns means  just one connection) :
&{0xc4200f0b40 {63665685693 529690519 0x6a8ec0} {63665685693 477671184 0x6a8ec0} <nil> <nil>} 2
&{0xc4200f0000 {63665685693 686820659 0x6a8ec0} {63665685693 475782445 0x6a8ec0} <nil> <nil>} 3
&{0xc4200f0500 {63665685693 687118147 0x6a8ec0} {63665685693 476507777 0x6a8ec0} <nil> <nil>} 5
&{0xc4200f0aa0 {63665685693 687100890 0x6a8ec0} {63665685693 477586003 0x6a8ec0} <nil> <nil>} 6
&{0xc4200f01e0 {63665685693 687109813 0x6a8ec0} {63665685693 476066754 0x6a8ec0} <nil> <nil>} 7
&{0xc4200f0640 {63665685693 687091533 0x6a8ec0} {63665685693 476730903 0x6a8ec0} <nil> <nil>} 7
&{0xc4200f0780 {63665685694 163423685 0x6a8ec0} {63665685693 476902825 0x6a8ec0} <nil> <nil>} 13
&{0xc4200f06e0 {63665685694 847118823 0x6a8ec0} {63665685693 476817492 0x6a8ec0} <nil> <nil>} 14
&{0xc4200f0a00 {63665685694 163440859 0x6a8ec0} {63665685693 477277888 0x6a8ec0} <nil> <nil>} 17
&{0xc4200f05a0 {63665685694 162762440 0x6a8ec0} {63665685693 476623582 0x6a8ec0} <nil> <nil>} 22
&{0xc4200f0460 {63665685694 163458348 0x6a8ec0} {63665685693 476408022 0x6a8ec0} <nil> <nil>} 25
&{0xc4200f0820 {63665685694 163449651 0x6a8ec0} {63665685693 477008788 0x6a8ec0} <nil> <nil>} 26
&{0xc4200f0280 {63665685694 741641136 0x6a8ec0} {63665685693 476149823 0x6a8ec0} <nil> <nil>} 33
&{0xc4200f0320 {63665685694 795203709 0x6a8ec0} {63665685693 476245743 0x6a8ec0} <nil> <nil>} 47
&{0xc4200f08c0 {63665685694 951248587 0x6a8ec0} {63665685693 477106928 0x6a8ec0} <nil> <nil>} 56
&{0xc4200f0960 {63665685694 951518854 0x6a8ec0} {63665685693 477164728 0x6a8ec0} <nil> <nil>} 66
&{0xc4200f0c80 {63665685698 597605597 0x6a8ec0} {63665685696 629367714 0x6a8ec0} 0xc4200d26e0 0xc4200e20f0} 134
&{0xc4200841e0 {63665685698 590350070 0x6a8ec0} {63665685696 891250636 0x6a8ec0} <nil> 0xc4200e2730} 142
&{0xc4200f03c0 {63665685697 307980917 0x6a8ec0} {63665685693 476304994 0x6a8ec0} <nil> <nil>} 256
&{0xc4200f0be0 {63665685698 612725018 0x6a8ec0} {63665685693 477753675 0x6a8ec0} 0xc4200e20a0 <nil>} 340
&{0xc4200f00a0 {63665685698 612714821 0x6a8ec0} {63665685693 475894536 0x6a8ec0} 0xc4200e20f0 0xc4200e2640} 389
&{0xc4200f0140 {63665685698 612565144 0x6a8ec0} {63665685693 475979714 0x6a8ec0} 0xc4200e2730 0xc4200e20a0} 390

I tested it like : 
for i:=0; i<20; i++ {
     go func(){
           for j:=0; j < 100; j++ {
                   conn := pool.Get();
                   conn.Do(cmd...);
                   conn.Close();
           }
     }();
}

 this lib will use the idle connection from list front , and return the connection to list front. If pool is inited by one ip and one port, like VIP:VPORT,  this will cause load not balance among the real server after VIP:VPORT. 

so， I think we can use the idle connection from list back, and return the connection to list front. I test this patch, the result like:

&{0xc4200843c0 {63665685806 813670377 0x6a8ec0} {63665685801 659183070 0x6a8ec0} 0xc4200c8370 0xc4200c8050} 99
&{0xc4200d6140 {63665685806 789457686 0x6a8ec0} {63665685801 601963854 0x6a8ec0} 0xc4200c8500 0xc4200c8320} 99
&{0xc4200d6280 {63665685806 776855060 0x6a8ec0} {63665685801 602277279 0x6a8ec0} 0xc420015ef0 0xc4200c8280} 99
&{0xc4200d6460 {63665685806 781422285 0x6a8ec0} {63665685801 602713542 0x6a8ec0} 0xc4200c8190 0xc4200c8500} 99
&{0xc4200d6a00 {63665685806 790319687 0x6a8ec0} {63665685801 659252693 0x6a8ec0} 0xc4200c8320 0xc4200c84b0} 99
&{0xc420084280 {63665685806 820758927 0x6a8ec0} {63665685801 605144499 0x6a8ec0} 0xc4200c8050 0xc4200c8230} 100
&{0xc420084320 {63665685806 774299055 0x6a8ec0} {63665685801 605594782 0x6a8ec0} 0xc4200c82d0 0xc4200c8190} 100
&{0xc4200d6000 {63665685806 818568972 0x6a8ec0} {63665685801 601605608 0x6a8ec0} 0xc420015f40 0xc420015ea0} 100
&{0xc4200d60a0 {63665685806 803503321 0x6a8ec0} {63665685801 601856349 0x6a8ec0} 0xc4200c8460 0xc4200c81e0} 100
&{0xc4200d61e0 {63665685806 801022702 0x6a8ec0} {63665685801 602105339 0x6a8ec0} 0xc4200c84b0 0xc4200c8460} 100
&{0xc4200d6320 {63665685806 803584668 0x6a8ec0} {63665685801 602427900 0x6a8ec0} 0xc4200c80a0 0xc4200c8410} 100
&{0xc4200d6500 {63665685806 771778947 0x6a8ec0} {63665685801 602838365 0x6a8ec0} <nil> 0xc420015ef0} 100
&{0xc4200d65a0 {63665685806 790288876 0x6a8ec0} {63665685801 602976151 0x6a8ec0} 0xc4200c80f0 0xc4200c8690} 100
&{0xc4200d6640 {63665685806 812176660 0x6a8ec0} {63665685801 603077035 0x6a8ec0} 0xc4200c8410 0xc420015f40} 100
&{0xc4200d6820 {63665685806 801906314 0x6a8ec0} {63665685801 603419223 0x6a8ec0} 0xc4200c8140 0xc4200c80a0} 100
&{0xc4200d68c0 {63665685806 797186497 0x6a8ec0} {63665685801 603514198 0x6a8ec0} 0xc4200c8690 0xc4200c8140} 100
&{0xc4200d6960 {63665685806 784789144 0x6a8ec0} {63665685801 603871798 0x6a8ec0} 0xc4200c8280 0xc4200c80f0} 100
&{0xc4200d63c0 {63665685806 823866192 0x6a8ec0} {63665685801 602560338 0x6a8ec0} 0xc420015ea0 0xc4200c83c0} 101
&{0xc4200d66e0 {63665685806 853648810 0x6a8ec0} {63665685801 603145208 0x6a8ec0} 0xc4200c8230 <nil>} 102
&{0xc4200d6780 {63665685806 807464413 0x6a8ec0} {63665685801 603288741 0x6a8ec0} 0xc4200c81e0 0xc4200c8370} 102