### PR TITLE
Migrate to Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/gomodule/redigo/v2

--- a/internal/redistest/testdb.go
+++ b/internal/redistest/testdb.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/gomodule/redigo/v2/redis"
 )
 
 type testConn struct {

--- a/redis/conn_test.go
+++ b/redis/conn_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/gomodule/redigo/v2/redis"
 )
 
 type testConn struct {

--- a/redis/pool.go
+++ b/redis/pool.go
@@ -25,7 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gomodule/redigo/internal"
+	"github.com/gomodule/redigo/v2/internal"
 )
 
 var (

--- a/redis/pool17_test.go
+++ b/redis/pool17_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/gomodule/redigo/v2/redis"
 )
 
 func TestWaitPoolGetContext(t *testing.T) {

--- a/redis/pool_test.go
+++ b/redis/pool_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/gomodule/redigo/v2/redis"
 )
 
 type poolTestConn struct {

--- a/redis/pubsub_example_test.go
+++ b/redis/pubsub_example_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/gomodule/redigo/v2/redis"
 )
 
 // listenPubSubChannels listens for messages on Redis pubsub channels. The

--- a/redis/pubsub_test.go
+++ b/redis/pubsub_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/gomodule/redigo/v2/redis"
 )
 
 func expectPushed(t *testing.T, c redis.PubSubConn, message string, expected interface{}) {

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/gomodule/redigo/v2/redis"
 )
 
 type timeoutTestConn int

--- a/redis/reply_test.go
+++ b/redis/reply_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/gomodule/redigo/v2/redis"
 )
 
 type valueError struct {

--- a/redis/scan_test.go
+++ b/redis/scan_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/gomodule/redigo/v2/redis"
 )
 
 type durationScan struct {

--- a/redis/script_test.go
+++ b/redis/script_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/gomodule/redigo/v2/redis"
 )
 
 var (

--- a/redis/zpop_example_test.go
+++ b/redis/zpop_example_test.go
@@ -17,7 +17,7 @@ package redis_test
 import (
 	"fmt"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/gomodule/redigo/v2/redis"
 )
 
 // zpop pops a value from the ZSET key using WATCH/MULTI/EXEC commands.

--- a/redisx/connmux.go
+++ b/redisx/connmux.go
@@ -18,8 +18,8 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/gomodule/redigo/internal"
-	"github.com/gomodule/redigo/redis"
+	"github.com/gomodule/redigo/v2/internal"
+	"github.com/gomodule/redigo/v2/redis"
 )
 
 // ConnMux multiplexes one or more connections to a single underlying

--- a/redisx/connmux_test.go
+++ b/redisx/connmux_test.go
@@ -19,9 +19,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/gomodule/redigo/internal/redistest"
-	"github.com/gomodule/redigo/redis"
-	"github.com/gomodule/redigo/redisx"
+	"github.com/gomodule/redigo/v2/internal/redistest"
+	"github.com/gomodule/redigo/v2/redis"
+	"github.com/gomodule/redigo/v2/redisx"
 )
 
 func TestConnMux(t *testing.T) {


### PR DESCRIPTION
This PR migrates the package to Go Modules and updates the path according to Semantic Import Versioning

Generated by https://github.com/marwan-at-work/mod