### PR TITLE
Add Pool Do and DoScript helpers

### DIFF
--- a/redis/pool.go
+++ b/redis/pool.go
@@ -253,6 +253,24 @@ func (p *Pool) Close() error {
 	return nil
 }
 
+// Do sends a command to the server and returns the received reply on a connection from the pool.
+// This can be used to easily minimize the time a connection is held from the pool for an individual Conn.Do.
+func (p *Pool) Do(command string, args ...interface{}) (reply interface{}, err error) {
+	c := p.Get()
+	defer c.Close()
+
+	return c.Do(command, args...)
+}
+
+// DoScript evaluates the script on a connection from the pool.
+// This can be used to easily minimize the time a connection is held from the pool for an individual Script.Do.
+func (p *Pool) DoScript(script *Script, args ...interface{}) (interface{}, error) {
+	c := p.Get()
+	defer c.Close()
+
+	return script.Do(c, args...)
+}
+
 func (p *Pool) lazyInit() {
 	// Fast path.
 	if atomic.LoadUint32(&p.chInitialized) == 1 {


### PR DESCRIPTION
Add Do and DoScript helpers to Pool which allow individual Do commands to be easily executed while holding a connection for a minimum amount of time.

This is important for apps which mix redis commands with other work, which would otherwise need to implement individual functions or closures which perform the Get / Close methods in order to avoid holding redis connections while not actually using them.