### PR TITLE
Issue#405 Support for SLOWLOG GET command

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -115,3 +115,19 @@ func ReceiveWithTimeout(c Conn, timeout time.Duration) (interface{}, error) {
 	}
 	return cwt.ReceiveWithTimeout(timeout)
 }
+
+// SlowLog represents a redis SlowLog
+// slowLogID - A unique progressive identifier for every slow log entry.
+// unixTimeStamp - The unix timestamp at which the logged command was processed.
+// executionTime - The amount of time needed for its execution, in microseconds.
+// args - The array composing the arguments of the command.
+// clientIPAddressAndPort - Client IP address and port (4.0 only).
+// clientName - Client name if set via the CLIENT SETNAME command (4.0 only).
+type SlowLog struct {
+	slowLogID              int64
+	unixTimeStamp          int64
+	executionTime          int64
+	args                   []string
+	clientIPAddressAndPort string
+	clientName             string
+}

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -121,8 +121,8 @@ type SlowLog struct {
 	// ID is a unique progressive identifier for every slow log entry.
 	ID int64
 
-	// UnixTime is the unix timestamp at which the logged command was processed.
-	UnixTime int64
+	// Time is the unix timestamp at which the logged command was processed.
+	Time time.Time
 
 	// ExecutationTime is the amount of time needed for the command execution.
 	ExecutionTime time.Duration

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -117,17 +117,22 @@ func ReceiveWithTimeout(c Conn, timeout time.Duration) (interface{}, error) {
 }
 
 // SlowLog represents a redis SlowLog
-// slowLogID - A unique progressive identifier for every slow log entry.
-// unixTimeStamp - The unix timestamp at which the logged command was processed.
-// executionTime - The amount of time needed for its execution, in microseconds.
-// args - The array composing the arguments of the command.
-// clientIPAddressAndPort - Client IP address and port (4.0 only).
-// clientName - Client name if set via the CLIENT SETNAME command (4.0 only).
 type SlowLog struct {
-	slowLogID              int64
-	unixTimeStamp          int64
-	executionTime          int64
-	args                   []string
-	clientIPAddressAndPort string
-	clientName             string
+	// ID is a unique progressive identifier for every slow log entry.
+	ID int64
+
+	// UnixTime is the unix timestamp at which the logged command was processed.
+	UnixTime int64
+
+	// ExecutationTime is the amount of time needed for the command execution.
+	ExecutionTime time.Duration
+
+	// Args is the command name and arguments
+	Args []string
+
+	// ClientAddr is the client IP address (4.0 only).
+	ClientAddr string
+
+	// ClientName is the name set via the CLIENT SETNAME command (4.0 only).
+	ClientName string
 }

--- a/redis/reply.go
+++ b/redis/reply.go
@@ -481,52 +481,53 @@ func Positions(result interface{}, err error) ([]*[2]float64, error) {
 
 // SlowLogs is a helper that parse the SLOWLOG GET command output and
 // return the array of SlowLog
-func SlowLogs(result interface{}, err error) ([]*SlowLog, error) {
+func SlowLogs(result interface{}, err error) ([]SlowLog, error) {
 	rawLogs, err := Values(result, err)
 	if err != nil {
 		return nil, err
 	}
-	logs := make([]*SlowLog, len(rawLogs))
+	logs := make([]SlowLog, len(rawLogs))
 	for i, rawLog := range rawLogs {
 		rawLog, ok := rawLog.([]interface{})
 		if !ok {
 			return nil, errors.New("redigo: slowlog element is not an array")
 		}
 
-		log := &SlowLog{}
-		logs[i] = log
+		var log SlowLog
 
 		if len(rawLog) < 4 {
 			return nil, errors.New("redigo: slowlog element has less than four elements")
 		}
 		log.ID, ok = rawLog[0].(int64)
 		if !ok {
-			return nil, errors.New("redigo: slowlog element[0] not an int")
+			return nil, errors.New("redigo: slowlog element[0] not an int64")
 		}
-		log.UnixTime, ok = rawLog[1].(int64)
+		timestamp, ok := rawLog[1].(int64)
 		if !ok {
-			return nil, errors.New("redigo: slowlog element[1] not an int")
+			return nil, errors.New("redigo: slowlog element[1] not an int64")
 		}
+		log.Time = time.Unix(timestamp, 0)
 		duration, ok := rawLog[2].(int64)
 		if !ok {
-			return nil, errors.New("redigo: slowlog element[2] not an int")
+			return nil, errors.New("redigo: slowlog element[2] not an int64")
 		}
 		log.ExecutionTime = time.Duration(duration) * time.Microsecond
 
 		log.Args, err = Strings(rawLog[3], nil)
 		if err != nil {
-			return nil, fmt.Errorf("redigo: slowlog element[3] is not array of string. actual error is : %w", err)
+			return nil, fmt.Errorf("redigo: slowlog element[3] is not array of string. actual error is : %s", err.Error())
 		}
 		if len(rawLog) >= 6 {
 			log.ClientAddr, err = String(rawLog[4], nil)
 			if err != nil {
-				return nil, fmt.Errorf("redigo: slowlog element[4] is not a string. actual error is : %w", err)
+				return nil, fmt.Errorf("redigo: slowlog element[4] is not a string. actual error is : %s", err.Error())
 			}
 			log.ClientName, err = String(rawLog[5], nil)
 			if err != nil {
-				return nil, fmt.Errorf("redigo: slowlog element[5] is not a string. actual error is : %w", err)
+				return nil, fmt.Errorf("redigo: slowlog element[5] is not a string. actual error is : %s", err.Error())
 			}
 		}
+		logs[i] = log
 	}
 	return logs, nil
 }


### PR DESCRIPTION
This PR provides support for SLOWLOG GET command results.  A new struct SlowLog has been added which contains the details of the SlowLogs obtained by calling the helper SlowLog

```go
// SlowLog represents a redis SlowLog
// slowLogID - A unique progressive identifier for every slow log entry.
// unixTimeStamp - The unix timestamp at which the logged command was processed.
// executionTime - The amount of time needed for its execution, in microseconds.
// args - The array composing the arguments of the command.
// clientIPAddressAndPort - Client IP address and port (4.0 only).
// clientName - Client name if set via the CLIENT SETNAME command (4.0 only).
type SlowLog struct {
	SlowLogID              int64
	UnixTimeStamp          int64
	ExecutionTime          int64
	Args                   []string
	ClientIPAddressAndPort string
	ClientName             string
}
```

Addresses: #405 