### PR TITLE
support scan to ptr and flatten from ptr

### DIFF
--- a/redis/scan.go
+++ b/redis/scan.go
@@ -626,8 +626,10 @@ func flattenStruct(args Args, v reflect.Value) Args {
 				continue
 			}
 		}
-		if fv.Kind() == reflect.Ptr {
-			args = append(args, fs.name, fv.Elem().Interface())
+		if fv.Kind() == reflect.Ptr  {
+			if !fv.IsNil() {
+				args = append(args, fs.name, fv.Elem().Interface())
+			}
 		} else {
 			args = append(args, fs.name, fv.Interface())
 		}

--- a/redis/scan.go
+++ b/redis/scan.go
@@ -626,7 +626,7 @@ func flattenStruct(args Args, v reflect.Value) Args {
 				continue
 			}
 		}
-		if fv.Kind() == reflect.Ptr  {
+		if fv.Kind() == reflect.Ptr {
 			if !fv.IsNil() {
 				args = append(args, fs.name, fv.Elem().Interface())
 			}

--- a/redis/scan.go
+++ b/redis/scan.go
@@ -99,6 +99,8 @@ func convertAssignString(d reflect.Value, s string) (err error) {
 		} else {
 			err = cannotConvert(d, s)
 		}
+	case reflect.Ptr:
+		err = convertAssignString(d.Elem(), s)
 	default:
 		err = cannotConvert(d, s)
 	}
@@ -624,7 +626,11 @@ func flattenStruct(args Args, v reflect.Value) Args {
 				continue
 			}
 		}
-		args = append(args, fs.name, fv.Interface())
+		if fv.Kind() == reflect.Ptr {
+			args = append(args, fs.name, fv.Elem().Interface())
+		} else {
+			args = append(args, fs.name, fv.Interface())
+		}
 	}
 	return args
 }

--- a/redis/scan_test.go
+++ b/redis/scan_test.go
@@ -432,8 +432,9 @@ var argsTests = []struct {
 			Bt bool
 			Bf bool
 			PtrB *bool
+			PtrI *int
 		}{
-			-1234, 5678, "hello", []byte("world"), map[string]string{"hello": "world"}, true, false, &boolTrue,
+			-1234, 5678, "hello", []byte("world"), map[string]string{"hello": "world"}, true, false, &boolTrue, nil,
 		}),
 		redis.Args{"i", int(-1234), "u", uint(5678), "s", "hello", "p", []byte("world"), "m", map[string]string{"hello": "world"}, "Bt", true, "Bf", false, "PtrB", true},
 	},

--- a/redis/scan_test.go
+++ b/redis/scan_test.go
@@ -207,10 +207,13 @@ type s1 struct {
 	B  bool   `redis:"b"`
 	Bt bool
 	Bf bool
+	PtrB *bool
 	s0
 	Sd  durationScan  `redis:"sd"`
 	Sdp *durationScan `redis:"sdp"`
 }
+
+var boolTrue = true
 
 var scanStructTests = []struct {
 	title string
@@ -226,6 +229,7 @@ var scanStructTests = []struct {
 			"b", "t",
 			"Bt", "1",
 			"Bf", "0",
+			"PtrB", "1",
 			"X", "123",
 			"y", "456",
 			"sd", "1m",
@@ -239,6 +243,7 @@ var scanStructTests = []struct {
 			B:   true,
 			Bt:  true,
 			Bf:  false,
+			PtrB: &boolTrue,
 			s0:  s0{X: 123, Y: 456},
 			Sd:  durationScan{Duration: time.Minute},
 			Sdp: &durationScan{Duration: time.Minute},
@@ -426,10 +431,11 @@ var argsTests = []struct {
 			M  map[string]string `redis:"m"`
 			Bt bool
 			Bf bool
+			PtrB *bool
 		}{
-			-1234, 5678, "hello", []byte("world"), map[string]string{"hello": "world"}, true, false,
+			-1234, 5678, "hello", []byte("world"), map[string]string{"hello": "world"}, true, false, &boolTrue,
 		}),
-		redis.Args{"i", int(-1234), "u", uint(5678), "s", "hello", "p", []byte("world"), "m", map[string]string{"hello": "world"}, "Bt", true, "Bf", false},
+		redis.Args{"i", int(-1234), "u", uint(5678), "s", "hello", "p", []byte("world"), "m", map[string]string{"hello": "world"}, "Bt", true, "Bf", false, "PtrB", true},
 	},
 	{"struct",
 		redis.Args{}.AddFlat(struct{ I int }{123}),

--- a/redis/scan_test.go
+++ b/redis/scan_test.go
@@ -199,14 +199,14 @@ type s0 struct {
 }
 
 type s1 struct {
-	X  int    `redis:"-"`
-	I  int    `redis:"i"`
-	U  uint   `redis:"u"`
-	S  string `redis:"s"`
-	P  []byte `redis:"p"`
-	B  bool   `redis:"b"`
-	Bt bool
-	Bf bool
+	X    int    `redis:"-"`
+	I    int    `redis:"i"`
+	U    uint   `redis:"u"`
+	S    string `redis:"s"`
+	P    []byte `redis:"p"`
+	B    bool   `redis:"b"`
+	Bt   bool
+	Bf   bool
 	PtrB *bool
 	s0
 	Sd  durationScan  `redis:"sd"`
@@ -236,17 +236,17 @@ var scanStructTests = []struct {
 			"sdp", "1m",
 		},
 		&s1{
-			I:   -1234,
-			U:   5678,
-			S:   "hello",
-			P:   []byte("world"),
-			B:   true,
-			Bt:  true,
-			Bf:  false,
+			I:    -1234,
+			U:    5678,
+			S:    "hello",
+			P:    []byte("world"),
+			B:    true,
+			Bt:   true,
+			Bf:   false,
 			PtrB: &boolTrue,
-			s0:  s0{X: 123, Y: 456},
-			Sd:  durationScan{Duration: time.Minute},
-			Sdp: &durationScan{Duration: time.Minute},
+			s0:   s0{X: 123, Y: 456},
+			Sd:   durationScan{Duration: time.Minute},
+			Sdp:  &durationScan{Duration: time.Minute},
 		},
 	},
 	{"absent values",
@@ -424,13 +424,13 @@ var argsTests = []struct {
 }{
 	{"struct ptr",
 		redis.Args{}.AddFlat(&struct {
-			I  int               `redis:"i"`
-			U  uint              `redis:"u"`
-			S  string            `redis:"s"`
-			P  []byte            `redis:"p"`
-			M  map[string]string `redis:"m"`
-			Bt bool
-			Bf bool
+			I    int               `redis:"i"`
+			U    uint              `redis:"u"`
+			S    string            `redis:"s"`
+			P    []byte            `redis:"p"`
+			M    map[string]string `redis:"m"`
+			Bt   bool
+			Bf   bool
 			PtrB *bool
 			PtrI *int
 		}{


### PR DESCRIPTION
This commit add code to support scan to struct with ptr fields, e.g.:

```
type S struct {
     PtrB *bool
}
```
and flattenStruct from the struct above.