### PR TITLE
addflat: respect RedisArg presence

### DIFF
--- a/redis/scan.go
+++ b/redis/scan.go
@@ -651,7 +651,11 @@ func flattenStruct(args Args, v reflect.Value) Args {
 				args = append(args, fs.name, fv.Elem().Interface())
 			}
 		} else {
-			args = append(args, fs.name, fv.Interface())
+			if arg, ok := fv.Interface().(Argument); ok {
+				args = append(args, fs.name, arg.RedisArg())
+			} else {
+				args = append(args, fs.name, fv.Interface())
+			}
 		}
 	}
 	return args

--- a/redis/scan_test.go
+++ b/redis/scan_test.go
@@ -444,6 +444,10 @@ var argsTests = []struct {
 		redis.Args{}.AddFlat(struct{ I int }{123}),
 		redis.Args{"I", 123},
 	},
+	{"struct with RedisArg",
+		redis.Args{}.AddFlat(struct{ T CustomTime }{CustomTime{Time: time.Unix(1573231058, 0)}}),
+		redis.Args{"T", int64(1573231058)},
+	},
 	{"slice",
 		redis.Args{}.Add(1).AddFlat([]string{"a", "b", "c"}).Add(2),
 		redis.Args{1, "a", "b", "c", 2},
@@ -464,6 +468,14 @@ func TestArgs(t *testing.T) {
 			t.Fatalf("%s is %v, want %v", tt.title, tt.actual, tt.expected)
 		}
 	}
+}
+
+type CustomTime struct {
+	time.Time
+}
+
+func (t CustomTime) RedisArg() interface{} {
+	return t.Unix()
 }
 
 type InnerStruct struct {


### PR DESCRIPTION
## Context

Given this scenario:

```
type User struct {
    CreatedAt Time `redis:"created_at"`
}

type Time struct {
    time.Time
}

func (t Time) RedisArg() interface{} {
  return t.Unix()
}
```

We'd have the custom `Time.RedisArg` be called when doing `AddFlat`.

Closes https://github.com/gomodule/redigo/issues/444