### PR TITLE
Simplify string reply check

### DIFF
--- a/redis/conn.go
+++ b/redis/conn.go
@@ -541,11 +541,11 @@ func (c *conn) readReply() (interface{}, error) {
 	}
 	switch line[0] {
 	case '+':
-		switch {
-		case len(line) == 3 && line[1] == 'O' && line[2] == 'K':
+		switch string(line[1:]) {
+		case "OK":
 			// Avoid allocation for frequent "+OK" response.
 			return okReply, nil
-		case len(line) == 5 && line[1] == 'P' && line[2] == 'O' && line[3] == 'N' && line[4] == 'G':
+		case "PONG":
 			// Avoid allocation in PING command benchmarks :)
 			return pongReply, nil
 		default:


### PR DESCRIPTION
The go compiler is smart enough to optimize string([]byte) conversion.

```
name       old time/op    new time/op    delta
DoPing-12    29.2µs ± 3%    29.3µs ± 4%   ~     (p=0.730 n=9+9)

name       old alloc/op   new alloc/op   delta
DoPing-12     0.00B          0.00B        ~     (all equal)

name       old allocs/op  new allocs/op  delta
DoPing-12      0.00           0.00        ~     (all equal)
```