### PR TITLE
chore: Remove validation against go prior to 1.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ services:
   - redis-server
 
 go:
-  - 1.7.x
-  - 1.8.x
   - 1.9.x
   - 1.10.x
   - 1.11.x


### PR DESCRIPTION
Remove travis validation against go prior to 1.9.x to allow v3 tagging
to take place: https://github.com/gomodule/redigo/pull/440