### PR TITLE
Add `WaitTimeout` to prevent `pool.Wait` blocking forever.

### DIFF
--- a/redis/pool_test.go
+++ b/redis/pool_test.go
@@ -404,6 +404,25 @@ func TestPoolMaxActive(t *testing.T) {
 	d.check("4", p, 2, 2, 1)
 }
 
+func TestPoolWait(t *testing.T) {
+	d := poolDialer{t: t}
+	p := &redis.Pool{
+		MaxIdle:      2,
+		MaxActive:    2,
+		Wait:         true,
+		WaitTimeout:  time.Millisecond * 10,
+		Dial:         d.dial,
+		TestOnBorrow: func(redis.Conn, time.Time) error { return redis.Error("BLAH") },
+	}
+	defer p.Close()
+
+	for i := 0; i < 10; i++ {
+		c := p.Get()
+		c.Do("PING")
+	}
+	d.check("1", p, 2, 2, 2)
+}
+
 func TestPoolWaitStats(t *testing.T) {
 	d := poolDialer{t: t}
 	p := &redis.Pool{


### PR DESCRIPTION
We use `pool.Wait` to serve high throughput requests.  `Wait` blocks forever, and there are scenarios where this behaviour can deadlock. For example `defer c.Close()` in nested functions can race and block forever. To avoid defer, one then has to `Get()` and `Close()` in multiple places, missing `Close()` in subtle ways. These have bitten us hard.

This PR adds an optional `pool.WaitTimeout` duration that returns `ErrPoolExhausted` when `Wait` is true without blocking forever.