### PR TITLE
Revert "Update README.markdown"

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,7 @@ Installation
 
 Install Redigo using the "go get" command:
 
-    go get github.com/gomodule/redigo
+    go get github.com/gomodule/redigo/redis
 
 The Go distribution is Redigo's only dependency.
 


### PR DESCRIPTION
Reverts gomodule/redigo#488

I read the diff backwards, so this should not have been merged as the original was correct.