### PR TITLE
fix(travis): Remove older versions of go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,13 @@ services:
   - redis-server
 
 go:
-  - 1.9.x
-  - 1.10.x
-  - 1.11.x
-  - 1.12.x
   - 1.13.x
   - 1.14.x
-  - tip
+  - master
 
 matrix:
   allow_failures:
-    - go: tip
+    - go: master
 
 script:
   - go get -t -v ./...


### PR DESCRIPTION
Remove older versions of go from travis config due to the testing dependency testify requiring errors.Is which is only available in go 1.13 and above.

Also switch to master from tip which is the new standard for travis.