### PR TITLE
Implement client side caching 

### DIFF
--- a/redisx/cacher.go
+++ b/redisx/cacher.go
@@ -1,0 +1,235 @@
+package redisx
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/gomodule/redigo/redis"
+)
+
+type cachingStrategy int
+
+const (
+	// Tracking strategy lets server to keep track of keys request by client
+	Tracking cachingStrategy = iota
+	// Broadcast strategy allows client to manually subscribe
+	// to invalidation broadcasts for interested keys
+	Broadcast
+)
+
+// Cacher implements client-side caching first appeared in Redis 6.0
+type Cacher struct {
+	Getter   ConnGetter
+	Strategy cachingStrategy
+
+	cache sync.Map // Actual cache. Not yet replaceble
+
+	mu  sync.Mutex // Guard for fields below
+	cid int        // Connection ID of invalidator process
+}
+
+// Matcher interface is used to determine whether key should be cached.
+// Allows for custom caching logic.
+type Matcher interface {
+	Match(key string) bool
+}
+
+type prefixMatcher []string
+
+// NewPrefixMatcher is a helper function that matches all keys with
+// supplied prefixes
+func NewPrefixMatcher(prefixes []string) Matcher {
+	return prefixMatcher(prefixes)
+}
+
+func (p prefixMatcher) Match(key string) bool {
+	for _, prefix := range p {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ConnGetter is interface used to get redis connection for Cacher usage
+type ConnGetter interface {
+	Get() redis.Conn
+}
+
+// ConnGetterFunc is an adapter type for ConnGetter interface
+type ConnGetterFunc func() redis.Conn
+
+// Get just calls underlying function
+func (f ConnGetterFunc) Get() redis.Conn {
+	return f()
+}
+
+// Run starts cache invalidation process. Must be called before any other
+// method if Tracking strategy is used. Closes provided channel when setup is done
+// Blocks caller.
+func (c *Cacher) Run(ctx context.Context, setupDoneChan chan<- struct{}) error {
+	// Connection used for invalidation
+	conn := c.Getter.Get()
+
+	id, err := redis.Int(conn.Do("CLIENT", "ID"))
+	if err != nil {
+		close(setupDoneChan)
+		return err
+	}
+
+	c.mu.Lock()
+	c.cid = id
+	c.mu.Unlock()
+
+	// Subscribe to revocation channel
+	err = conn.Send("SUBSCRIBE", "__redis__:invalidate")
+	if err != nil {
+		close(setupDoneChan)
+		return err
+	}
+
+	conn.Flush()
+	if err != nil {
+		close(setupDoneChan)
+		return err
+	}
+
+	close(setupDoneChan)
+
+outer:
+	for {
+		select {
+		case <-ctx.Done():
+			break outer
+		default:
+			event, err := redis.Values(conn.Receive())
+			if err != nil {
+				continue
+			}
+
+			evType, _ := redis.String(event[0], nil)
+
+			if evType == "message" {
+				// Remove revoked keys from local cache
+				keys, err := redis.Strings(event[2], nil)
+				if err != nil {
+					continue
+				}
+
+				for _, key := range keys {
+					c.cache.Delete(key)
+				}
+			}
+		}
+	}
+
+	c.mu.Lock()
+	c.cid = 0
+	c.mu.Unlock()
+
+	return ctx.Err()
+}
+
+// Get returns a connection with caching enabled for matched keys.
+// If nil Matcher is passed all keys are subjected to cache.
+// Caller is responsible for closing connection.
+func (c *Cacher) Get(m Matcher) redis.Conn {
+	if c.Getter == nil {
+		panic("redisx cacher: cannot Get: no getter supplied")
+	}
+	return c.Wrap(c.Getter.Get(), m)
+}
+
+// Wrap allows wrapping existing connection with caching layer
+func (c *Cacher) Wrap(conn redis.Conn, m Matcher) redis.Conn {
+	c.mu.Lock()
+	cid := c.cid
+	c.mu.Unlock()
+
+	if cid == 0 {
+		panic("redisx cacher: invalidation process is not running")
+	}
+
+	_, err := conn.Do("CLIENT", "TRACKING", "on", "REDIRECT", cid)
+	if err != nil {
+		return errorConn{err}
+	}
+
+	return wrappedConn{c, conn, m}
+}
+
+// Stats return aggregated stats about local cache
+func (c *Cacher) Stats() CacheStats {
+	entries := 0
+	c.cache.Range(func(key, value interface{}) bool {
+		entries++
+		return true
+	})
+	return CacheStats{entries}
+}
+
+// CacheStats contain statistics about local cache
+type CacheStats struct {
+	Entries int
+}
+
+type wrappedConn struct {
+	c       *Cacher
+	conn    redis.Conn
+	matcher Matcher
+}
+
+func (w wrappedConn) Close() error { return w.conn.Close() }
+
+func (w wrappedConn) Err() error { return w.conn.Err() }
+
+func (w wrappedConn) Do(commandName string, args ...interface{}) (reply interface{}, err error) {
+	// Only GET is supported for now
+	if commandName == "GET" {
+		key, ok := args[0].(string)
+
+		if !ok {
+			return w.conn.Do(commandName, args...)
+		}
+
+		if w.matcher != nil && !w.matcher.Match(key) {
+			return w.conn.Do(commandName, args...)
+		}
+
+		// Happy path
+		if entry, ok := w.c.cache.Load(key); ok {
+			return entry, nil
+		}
+
+		reply, err := w.conn.Do(commandName, args...)
+		if err != nil {
+			return reply, err
+		}
+
+		// Cache response
+		w.c.cache.Store(key, reply)
+		return reply, nil
+	}
+
+	return w.conn.Do(commandName, args...)
+}
+
+func (w wrappedConn) Send(commandName string, args ...interface{}) error {
+	return w.conn.Send(commandName, args...)
+}
+
+func (w wrappedConn) Flush() error { return w.conn.Flush() }
+
+func (w wrappedConn) Receive() (reply interface{}, err error) { return w.conn.Receive() }
+
+//
+type errorConn struct{ err error }
+
+func (ec errorConn) Do(string, ...interface{}) (interface{}, error) { return nil, ec.err }
+func (ec errorConn) Send(string, ...interface{}) error              { return ec.err }
+func (ec errorConn) Err() error                                     { return ec.err }
+func (ec errorConn) Close() error                                   { return nil }
+func (ec errorConn) Flush() error                                   { return ec.err }
+func (ec errorConn) Receive() (interface{}, error)                  { return nil, ec.err }

--- a/redisx/cacher_test.go
+++ b/redisx/cacher_test.go
@@ -1,0 +1,94 @@
+package redisx
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCacherTracking(t *testing.T) {
+	c, cleanup := setupCacher(t)
+	defer cleanup()
+
+	conn := c.Get(nil)
+
+	_, err := conn.Do("SET", "k", "v")
+	assert.Nil(t, err)
+
+	_, err = conn.Do("GET", "k")
+	assert.Nil(t, err)
+
+	value, err := redis.String(conn.Do("GET", "k"))
+	assert.Equal(t, "v", value) // Make sure stored value is correct
+	assert.Nil(t, err)
+
+	// Should be in cache now
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, 1, c.Stats().Entries)
+
+	_, err = conn.Do("SET", "k", "v2")
+	assert.Nil(t, err)
+
+	// Value changed. Cache is no longer valid
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, 0, c.Stats().Entries)
+}
+
+func TestCacherWithoutInvalidationProcess(t *testing.T) {
+	c, close := setupCacher(t)
+	close()
+
+	assert.Panics(t, func() {
+		c.Get(nil)
+	}, "should panic")
+}
+
+func TestCacherNilGetter(t *testing.T) {
+	c := &Cacher{
+		Getter: nil,
+	}
+
+	assert.Panics(t, func() {
+		c.Get(nil)
+	})
+}
+
+func setupCacher(t *testing.T) (c *Cacher, cleanup func()) {
+	getter := ConnGetterFunc(func() redis.Conn {
+		conn, err := redis.Dial("tcp", ":6379")
+		assert.Nil(t, err)
+
+		return conn
+	})
+
+	c = &Cacher{
+		Getter:   getter,
+		Strategy: Tracking,
+	}
+
+	ctx, cleanup := context.WithCancel(context.Background())
+
+	setupDone := make(chan struct{})
+	go func() {
+		t.Log("Starting invalidator")
+		err := c.Run(ctx, setupDone)
+		if err != context.Canceled {
+			t.Errorf("unexpected error: %v", err)
+			panic(123)
+		}
+	}()
+	<-setupDone
+
+	return
+}
+
+func TestPrefixMatcher(t *testing.T) {
+	m := NewPrefixMatcher([]string{"user:", "object:"})
+	assert.True(t, m.Match("user:123"))
+	assert.True(t, m.Match("user:"))
+	assert.True(t, m.Match("object:blah"))
+	assert.False(t, m.Match("admin:666"))
+}


### PR DESCRIPTION
**This PR implements server-assisted client side caching [introduced](https://redis.io/topics/client-side-caching) in Redis 6.0**

This is done entirely at a pool level by running a separate goroutine that subscribes to invalidation broadcasts.
Command responses are, again, cached by middleware at a pool level.

The implementation is very naive and I wanted to make sure I'm going in the right direction.

Not yet implemented:
* Cache size limit
* Broadcasting mode
* Opt-in caching
* Keeping track of TTL
* Caching other types

closes #513