### PR TITLE
fix: open connection count

### DIFF
--- a/redis/pool.go
+++ b/redis/pool.go
@@ -387,6 +387,7 @@ func (p *Pool) waitVacantConn(ctx context.Context) (waited time.Duration, err er
 		// because `select` picks a random `case` if several of them are "ready".
 		select {
 		case <-ctx.Done():
+			p.ch <- struct{}{}
 			return 0, ctx.Err()
 		default:
 		}


### PR DESCRIPTION
This commit releases back the connection in the special
case, so that correct count is always maintained.

Closes #520 