### PR TITLE
Add End of terms and conditions in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -173,3 +173,5 @@
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS


### PR DESCRIPTION
These missing lines was preventing the license_finder gem from detecting
a valid Apache 2.0 license.