### PR TITLE
add DoContext and ReceiveContext,use context to control the life

### DIFF
--- a/redis/conn.go
+++ b/redis/conn.go
@@ -685,7 +685,7 @@ func (c *conn) ReceiveContext(ctx context.Context) (interface{}, error) {
 		if timeout >= c.readTimeout && c.readTimeout != 0 {
 			realtimeout = c.readTimeout
 		} else if timeout <= 0 {
-			return nil, c.fatal(ErrContextCacneled)
+			return nil, c.fatal(ErrContextCanceled)
 		} else {
 			realtimeout = timeout
 		}
@@ -702,7 +702,7 @@ func (c *conn) ReceiveContext(ctx context.Context) (interface{}, error) {
 	}()
 	select {
 	case <-ctx.Done():
-		return nil, c.fatal(ErrContextCacneled)
+		return nil, c.fatal(ErrContextCanceled)
 	case <-endch:
 		return r, e
 	}
@@ -747,7 +747,7 @@ func (c *conn) DoContext(ctx context.Context, cmd string, args ...interface{}) (
 		if timeout >= c.readTimeout && c.readTimeout != 0 {
 			realtimeout = c.readTimeout
 		} else if timeout <= 0 {
-			return nil, c.fatal(ErrContextCacneled)
+			return nil, c.fatal(ErrContextCanceled)
 		} else {
 			realtimeout = timeout
 		}
@@ -764,7 +764,7 @@ func (c *conn) DoContext(ctx context.Context, cmd string, args ...interface{}) (
 	}()
 	select {
 	case <-ctx.Done():
-		return nil, c.fatal(ErrContextCacneled)
+		return nil, c.fatal(ErrContextCanceled)
 	case <-endch:
 		return r, e
 	}

--- a/redis/conn.go
+++ b/redis/conn.go
@@ -685,7 +685,7 @@ func (c *conn) ReceiveContext(ctx context.Context) (interface{}, error) {
 		if timeout >= c.readTimeout && c.readTimeout != 0 {
 			realtimeout = c.readTimeout
 		} else if timeout <= 0 {
-			return nil, c.fatal(ErrContextCanceled)
+			return nil, c.fatal(context.DeadlineExceeded)
 		} else {
 			realtimeout = timeout
 		}
@@ -702,7 +702,7 @@ func (c *conn) ReceiveContext(ctx context.Context) (interface{}, error) {
 	}()
 	select {
 	case <-ctx.Done():
-		return nil, c.fatal(ErrContextCanceled)
+		return nil, c.fatal(ctx.Err())
 	case <-endch:
 		return r, e
 	}
@@ -747,7 +747,7 @@ func (c *conn) DoContext(ctx context.Context, cmd string, args ...interface{}) (
 		if timeout >= c.readTimeout && c.readTimeout != 0 {
 			realtimeout = c.readTimeout
 		} else if timeout <= 0 {
-			return nil, c.fatal(ErrContextCanceled)
+			return nil, c.fatal(context.DeadlineExceeded)
 		} else {
 			realtimeout = timeout
 		}
@@ -764,7 +764,7 @@ func (c *conn) DoContext(ctx context.Context, cmd string, args ...interface{}) (
 	}()
 	select {
 	case <-ctx.Done():
-		return nil, c.fatal(ErrContextCanceled)
+		return nil, c.fatal(ctx.Err())
 	case <-endch:
 		return r, e
 	}

--- a/redis/conn.go
+++ b/redis/conn.go
@@ -679,18 +679,18 @@ func (c *conn) Receive() (interface{}, error) {
 }
 
 func (c *conn) ReceiveContext(ctx context.Context) (interface{}, error) {
-	var realtimeout time.Duration
+	var realTimeout time.Duration
 	if dl, ok := ctx.Deadline(); ok {
 		timeout := time.Until(dl)
 		if timeout >= c.readTimeout && c.readTimeout != 0 {
-			realtimeout = c.readTimeout
+			realTimeout = c.readTimeout
 		} else if timeout <= 0 {
 			return nil, c.fatal(context.DeadlineExceeded)
 		} else {
-			realtimeout = timeout
+			realTimeout = timeout
 		}
 	} else {
-		realtimeout = c.readTimeout
+		realTimeout = c.readTimeout
 	}
 	endch := make(chan struct{})
 	var r interface{}
@@ -698,7 +698,7 @@ func (c *conn) ReceiveContext(ctx context.Context) (interface{}, error) {
 	go func() {
 		defer close(endch)
 
-		r, e = c.ReceiveWithTimeout(realtimeout)
+		r, e = c.ReceiveWithTimeout(realTimeout)
 	}()
 	select {
 	case <-ctx.Done():
@@ -741,18 +741,18 @@ func (c *conn) Do(cmd string, args ...interface{}) (interface{}, error) {
 }
 
 func (c *conn) DoContext(ctx context.Context, cmd string, args ...interface{}) (interface{}, error) {
-	var realtimeout time.Duration
+	var realTimeout time.Duration
 	if dl, ok := ctx.Deadline(); ok {
 		timeout := time.Until(dl)
 		if timeout >= c.readTimeout && c.readTimeout != 0 {
-			realtimeout = c.readTimeout
+			realTimeout = c.readTimeout
 		} else if timeout <= 0 {
 			return nil, c.fatal(context.DeadlineExceeded)
 		} else {
-			realtimeout = timeout
+			realTimeout = timeout
 		}
 	} else {
-		realtimeout = c.readTimeout
+		realTimeout = c.readTimeout
 	}
 	endch := make(chan struct{})
 	var r interface{}
@@ -760,7 +760,7 @@ func (c *conn) DoContext(ctx context.Context, cmd string, args ...interface{}) (
 	go func() {
 		defer close(endch)
 
-		r, e = c.DoWithTimeout(realtimeout, cmd, args)
+		r, e = c.DoWithTimeout(realTimeout, cmd, args)
 	}()
 	select {
 	case <-ctx.Done():

--- a/redis/log.go
+++ b/redis/log.go
@@ -16,6 +16,7 @@ package redis
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -121,6 +122,12 @@ func (c *loggingConn) Do(commandName string, args ...interface{}) (interface{}, 
 	return reply, err
 }
 
+func (c *loggingConn) DoContext(ctx context.Context, commandName string, args ...interface{}) (interface{}, error) {
+	reply, err := DoContext(c.Conn, ctx, commandName, args...)
+	c.print("DoContext", commandName, args, reply, err)
+	return reply, err
+}
+
 func (c *loggingConn) DoWithTimeout(timeout time.Duration, commandName string, args ...interface{}) (interface{}, error) {
 	reply, err := DoWithTimeout(c.Conn, timeout, commandName, args...)
 	c.print("DoWithTimeout", commandName, args, reply, err)
@@ -136,6 +143,12 @@ func (c *loggingConn) Send(commandName string, args ...interface{}) error {
 func (c *loggingConn) Receive() (interface{}, error) {
 	reply, err := c.Conn.Receive()
 	c.print("Receive", "", nil, reply, err)
+	return reply, err
+}
+
+func (c *loggingConn) ReceiveContext(ctx context.Context) (interface{}, error) {
+	reply, err := ReceiveContext(c.Conn, ctx)
+	c.print("ReceiveContext", "", nil, reply, err)
 	return reply, err
 }
 

--- a/redis/pool.go
+++ b/redis/pool.go
@@ -496,6 +496,19 @@ func (ac *activeConn) Err() error {
 	}
 	return pc.c.Err()
 }
+func (ac *activeConn) DoContext(ctx context.Context, commandName string, args ...interface{}) (reply interface{}, err error) {
+	pc := ac.pc
+	if pc == nil {
+		return nil, errConnClosed
+	}
+	cwt, ok := pc.c.(ConnWithContext)
+	if !ok {
+		return nil, errContextNotSupported
+	}
+	ci := lookupCommandInfo(commandName)
+	ac.state = (ac.state | ci.Set) &^ ci.Clear
+	return cwt.DoContext(ctx, commandName, args...)
+}
 
 func (ac *activeConn) Do(commandName string, args ...interface{}) (reply interface{}, err error) {
 	pc := ac.pc
@@ -546,7 +559,17 @@ func (ac *activeConn) Receive() (reply interface{}, err error) {
 	}
 	return pc.c.Receive()
 }
-
+func (ac *activeConn) ReceiveContext(ctx context.Context) (reply interface{}, err error) {
+	pc := ac.pc
+	if pc == nil {
+		return nil, errConnClosed
+	}
+	cwt, ok := pc.c.(ConnWithContext)
+	if !ok {
+		return nil, errContextNotSupported
+	}
+	return cwt.ReceiveContext(ctx)
+}
 func (ac *activeConn) ReceiveWithTimeout(timeout time.Duration) (reply interface{}, err error) {
 	pc := ac.pc
 	if pc == nil {
@@ -562,6 +585,9 @@ func (ac *activeConn) ReceiveWithTimeout(timeout time.Duration) (reply interface
 type errorConn struct{ err error }
 
 func (ec errorConn) Do(string, ...interface{}) (interface{}, error) { return nil, ec.err }
+func (ec errorConn) DoContext(context.Context, string, ...interface{}) (interface{}, error) {
+	return nil, ec.err
+}
 func (ec errorConn) DoWithTimeout(time.Duration, string, ...interface{}) (interface{}, error) {
 	return nil, ec.err
 }
@@ -570,6 +596,7 @@ func (ec errorConn) Err() error                                            { ret
 func (ec errorConn) Close() error                                          { return nil }
 func (ec errorConn) Flush() error                                          { return ec.err }
 func (ec errorConn) Receive() (interface{}, error)                         { return nil, ec.err }
+func (ec errorConn) ReceiveContext(context.Context) (interface{}, error)   { return nil, ec.err }
 func (ec errorConn) ReceiveWithTimeout(time.Duration) (interface{}, error) { return nil, ec.err }
 
 type idleList struct {

--- a/redis/pool.go
+++ b/redis/pool.go
@@ -496,6 +496,7 @@ func (ac *activeConn) Err() error {
 	}
 	return pc.c.Err()
 }
+
 func (ac *activeConn) DoContext(ctx context.Context, commandName string, args ...interface{}) (reply interface{}, err error) {
 	pc := ac.pc
 	if pc == nil {
@@ -559,6 +560,7 @@ func (ac *activeConn) Receive() (reply interface{}, err error) {
 	}
 	return pc.c.Receive()
 }
+
 func (ac *activeConn) ReceiveContext(ctx context.Context) (reply interface{}, err error) {
 	pc := ac.pc
 	if pc == nil {
@@ -570,6 +572,7 @@ func (ac *activeConn) ReceiveContext(ctx context.Context) (reply interface{}, er
 	}
 	return cwt.ReceiveContext(ctx)
 }
+
 func (ac *activeConn) ReceiveWithTimeout(timeout time.Duration) (reply interface{}, err error) {
 	pc := ac.pc
 	if pc == nil {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -109,7 +109,7 @@ type ConnWithContext interface {
 var errTimeoutNotSupported = errors.New("redis: connection does not support ConnWithTimeout")
 var errContextNotSupported = errors.New("redis: connection does not support ConnWithContext")
 
-var ErrContextCacneled = errors.New("redis: context canceled")
+var ErrContextCanceled = errors.New("redis: context canceled")
 
 // DoContext sends a command to server and returns the received reply.
 // The connection will be closed if ctx timeout or cancel when this function is running and an error "ErrContextCacneled" will return

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -15,6 +15,7 @@
 package redis
 
 import (
+	"context"
 	"errors"
 	"time"
 )
@@ -33,6 +34,7 @@ type Conn interface {
 	Err() error
 
 	// Do sends a command to the server and returns the received reply.
+	// This function will use the timeout which was setted when the connection is created
 	Do(commandName string, args ...interface{}) (reply interface{}, err error)
 
 	// Send writes the command to the client's output buffer.
@@ -82,17 +84,54 @@ type Scanner interface {
 type ConnWithTimeout interface {
 	Conn
 
-	// Do sends a command to the server and returns the received reply.
-	// The timeout overrides the read timeout set when dialing the
-	// connection.
+	// DoWithTimeout sends a command to the server and returns the received reply.
+	// The timeout overrides the readtimeout set when dialing the connection.
 	DoWithTimeout(timeout time.Duration, commandName string, args ...interface{}) (reply interface{}, err error)
 
-	// Receive receives a single reply from the Redis server. The timeout
-	// overrides the read timeout set when dialing the connection.
+	// ReceiveWithTimeout receives a single reply from the Redis server.
+	// The timeout overrides the readtimeout set when dialing the connection.
 	ReceiveWithTimeout(timeout time.Duration) (reply interface{}, err error)
 }
 
+// ConnWithContext is an optional interface that allows the caller to control the command's life with context
+type ConnWithContext interface {
+	Conn
+
+	// DoContext sends a command to server and returns the received reply.
+	// This function will use the timeout in this rule:
+	// If ctx doesn't have a timeout(ctx is context.Background or context.TODO),then the readtimeout which was setted when the connection is created will be used
+	// If ctx has a timeout(ctx is created by context.WithTimeout or context.WithDeadline)
+	// If ctx's timeout is bigger then the readtimeout which was setted when the connection is created,then the readtimeout will be used
+	// If ctx's timeout is smaller then the readtimeout which was setted when the connection is created,then the ctx's timeout will be used
+	DoContext(ctx context.Context, commandName string, args ...interface{}) (reply interface{}, err error)
+
+	// ReceiveContext receives a single reply from the Redis server.
+	// This function will use the timeout in this rule:
+	// If ctx doesn't have a timeout(ctx is context.Background or context.TODO),then the readtimeout which was setted when the connection is created will be used
+	// If ctx has a timeout(ctx is created by context.WithTimeout or context.WithDeadline)
+	// If ctx's timeout is bigger then the readtimeout which was setted when the connection is created,then the readtimeout will be used
+	// If ctx's timeout is smaller then the readtimeout which was setted when the connection is created,then the ctx's timeout will be used
+	ReceiveContext(ctx context.Context) (reply interface{}, err error)
+}
+
 var errTimeoutNotSupported = errors.New("redis: connection does not support ConnWithTimeout")
+var errContextNotSupported = errors.New("redis: connection does not support ConnWithContext")
+
+var ErrContextCacneled = errors.New("redis: context canceled")
+
+// DoContext sends a command to server and returns the received reply.
+// This function will use the timeout in this rule:
+// If ctx doesn't have a timeout(ctx is context.Background or context.TODO),then the readtimeout which was setted when the connection is created will be used
+// If ctx has a timeout(ctx is created by context.WithTimeout or context.WithDeadline)
+// If ctx's timeout is bigger then the readtimeout which was setted when the connection is created,then the readtimeout will be used
+// If ctx's timeout is smaller then the readtimeout which was setted when the connection is created,then the ctx's timeout will be used
+func DoContext(c Conn, ctx context.Context, cmd string, args ...interface{}) (interface{}, error) {
+	cwt, ok := c.(ConnWithContext)
+	if !ok {
+		return nil, errContextNotSupported
+	}
+	return cwt.DoContext(ctx, cmd, args...)
+}
 
 // DoWithTimeout executes a Redis command with the specified read timeout. If
 // the connection does not satisfy the ConnWithTimeout interface, then an error
@@ -103,6 +142,20 @@ func DoWithTimeout(c Conn, timeout time.Duration, cmd string, args ...interface{
 		return nil, errTimeoutNotSupported
 	}
 	return cwt.DoWithTimeout(timeout, cmd, args...)
+}
+
+// ReceiveContext receives a single reply from the Redis server.
+// This function will use the timeout in this rule:
+// If ctx doesn't have a timeout(ctx is context.Background or context.TODO),then the readtimeout which was setted when the connection is created will be used
+// If ctx has a timeout(ctx is created by context.WithTimeout or context.WithDeadline)
+// If ctx's timeout is bigger then the readtimeout which was setted when the connection is created,then the readtimeout will be used
+// If ctx's timeout is smaller then the readtimeout which was setted when the connection is created,then the ctx's timeout will be used
+func ReceiveContext(c Conn, ctx context.Context) (interface{}, error) {
+	cwt, ok := c.(ConnWithContext)
+	if !ok {
+		return nil, errContextNotSupported
+	}
+	return cwt.ReceiveContext(ctx)
 }
 
 // ReceiveWithTimeout receives a reply with the specified read timeout. If the

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -109,7 +109,7 @@ type ConnWithContext interface {
 var errTimeoutNotSupported = errors.New("redis: connection does not support ConnWithTimeout")
 var errContextNotSupported = errors.New("redis: connection does not support ConnWithContext")
 
-var ErrContextCanceled = errors.New("redis: context canceled")
+//var ErrContextCanceled = errors.New("redis: context canceled")
 
 // DoContext sends a command to server and returns the received reply.
 // The connection will be closed if ctx timeout or cancel when this function is running and an error "ErrContextCacneled" will return

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -98,19 +98,11 @@ type ConnWithContext interface {
 	Conn
 
 	// DoContext sends a command to server and returns the received reply.
-	// This function will use the timeout in this rule:
-	// If ctx doesn't have a timeout(ctx is context.Background or context.TODO),then the readtimeout which was setted when the connection is created will be used
-	// If ctx has a timeout(ctx is created by context.WithTimeout or context.WithDeadline)
-	// If ctx's timeout is bigger then the readtimeout which was setted when the connection is created,then the readtimeout will be used
-	// If ctx's timeout is smaller then the readtimeout which was setted when the connection is created,then the ctx's timeout will be used
+	// The connection will be closed if ctx timeout or cancel when this function is running and an error "ErrContextCacneled" will return
 	DoContext(ctx context.Context, commandName string, args ...interface{}) (reply interface{}, err error)
 
 	// ReceiveContext receives a single reply from the Redis server.
-	// This function will use the timeout in this rule:
-	// If ctx doesn't have a timeout(ctx is context.Background or context.TODO),then the readtimeout which was setted when the connection is created will be used
-	// If ctx has a timeout(ctx is created by context.WithTimeout or context.WithDeadline)
-	// If ctx's timeout is bigger then the readtimeout which was setted when the connection is created,then the readtimeout will be used
-	// If ctx's timeout is smaller then the readtimeout which was setted when the connection is created,then the ctx's timeout will be used
+	// The connection will be closed if ctx timeout or cancel when this function is running and an error "ErrContextCacneled" will return
 	ReceiveContext(ctx context.Context) (reply interface{}, err error)
 }
 
@@ -120,11 +112,7 @@ var errContextNotSupported = errors.New("redis: connection does not support Conn
 var ErrContextCacneled = errors.New("redis: context canceled")
 
 // DoContext sends a command to server and returns the received reply.
-// This function will use the timeout in this rule:
-// If ctx doesn't have a timeout(ctx is context.Background or context.TODO),then the readtimeout which was setted when the connection is created will be used
-// If ctx has a timeout(ctx is created by context.WithTimeout or context.WithDeadline)
-// If ctx's timeout is bigger then the readtimeout which was setted when the connection is created,then the readtimeout will be used
-// If ctx's timeout is smaller then the readtimeout which was setted when the connection is created,then the ctx's timeout will be used
+// The connection will be closed if ctx timeout or cancel when this function is running and an error "ErrContextCacneled" will return
 func DoContext(c Conn, ctx context.Context, cmd string, args ...interface{}) (interface{}, error) {
 	cwt, ok := c.(ConnWithContext)
 	if !ok {
@@ -145,11 +133,7 @@ func DoWithTimeout(c Conn, timeout time.Duration, cmd string, args ...interface{
 }
 
 // ReceiveContext receives a single reply from the Redis server.
-// This function will use the timeout in this rule:
-// If ctx doesn't have a timeout(ctx is context.Background or context.TODO),then the readtimeout which was setted when the connection is created will be used
-// If ctx has a timeout(ctx is created by context.WithTimeout or context.WithDeadline)
-// If ctx's timeout is bigger then the readtimeout which was setted when the connection is created,then the readtimeout will be used
-// If ctx's timeout is smaller then the readtimeout which was setted when the connection is created,then the ctx's timeout will be used
+// The connection will be closed if ctx timeout or cancel when this function is running and an error "ErrContextCacneled" will return
 func ReceiveContext(c Conn, ctx context.Context) (interface{}, error) {
 	cwt, ok := c.(ConnWithContext)
 	if !ok {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -34,7 +34,7 @@ type Conn interface {
 	Err() error
 
 	// Do sends a command to the server and returns the received reply.
-	// This function will use the timeout which was setted when the connection is created
+	// This function will use the timeout which was set when the connection is created
 	Do(commandName string, args ...interface{}) (reply interface{}, err error)
 
 	// Send writes the command to the client's output buffer.

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -100,7 +100,7 @@ type ConnWithContext interface {
 	// DoContext sends a command to server and returns the received reply.
 	// min(ctx,DialReadTimeout()) will be used as the deadline.
 	// The connection will be closed if DialReadTimeout() timeout or ctx timeout or ctx canceled when this function is running.
-	// DailReadTimeout() timeout return err can be checked by strings.Contains(e.Error(), "io/timeout").
+	// DialReadTimeout() timeout return err can be checked by strings.Contains(e.Error(), "io/timeout").
 	// ctx timeout return err context.DeadlineExceeded.
 	// ctx canceled return err context.Canceled.
 	DoContext(ctx context.Context, commandName string, args ...interface{}) (reply interface{}, err error)
@@ -108,7 +108,7 @@ type ConnWithContext interface {
 	// ReceiveContext receives a single reply from the Redis server.
 	// min(ctx,DialReadTimeout()) will be used as the deadline.
 	// The connection will be closed if DialReadTimeout() timeout or ctx timeout or ctx canceled when this function is running.
-	// DailReadTimeout() timeout return err can be checked by strings.Contains(e.Error(), "io/timeout").
+	// DialReadTimeout() timeout return err can be checked by strings.Contains(e.Error(), "io/timeout").
 	// ctx timeout return err context.DeadlineExceeded.
 	// ctx canceled return err context.Canceled.
 	ReceiveContext(ctx context.Context) (reply interface{}, err error)
@@ -120,7 +120,7 @@ var errContextNotSupported = errors.New("redis: connection does not support Conn
 // DoContext sends a command to server and returns the received reply.
 // min(ctx,DialReadTimeout()) will be used as the deadline.
 // The connection will be closed if DialReadTimeout() timeout or ctx timeout or ctx canceled when this function is running.
-// DailReadTimeout() timeout return err can be checked by strings.Contains(e.Error(), "io/timeout").
+// DialReadTimeout() timeout return err can be checked by strings.Contains(e.Error(), "io/timeout").
 // ctx timeout return err context.DeadlineExceeded.
 // ctx canceled return err context.Canceled.
 func DoContext(c Conn, ctx context.Context, cmd string, args ...interface{}) (interface{}, error) {
@@ -145,7 +145,7 @@ func DoWithTimeout(c Conn, timeout time.Duration, cmd string, args ...interface{
 // ReceiveContext receives a single reply from the Redis server.
 // min(ctx,DialReadTimeout()) will be used as the deadline.
 // The connection will be closed if DialReadTimeout() timeout or ctx timeout or ctx canceled when this function is running.
-// DailReadTimeout() timeout return err can be checked by strings.Contains(e.Error(), "io/timeout").
+// DialReadTimeout() timeout return err can be checked by strings.Contains(e.Error(), "io/timeout").
 // ctx timeout return err context.DeadlineExceeded.
 // ctx canceled return err context.Canceled.
 func ReceiveContext(c Conn, ctx context.Context) (interface{}, error) {

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -32,9 +32,11 @@ func (tc timeoutTestConn) DoContext(ctx context.Context, cms string, args ...int
 		return time.Duration(-1), nil
 	}
 }
+
 func (tc timeoutTestConn) Do(string, ...interface{}) (interface{}, error) {
 	return time.Duration(-1), nil
 }
+
 func (tc timeoutTestConn) DoWithTimeout(timeout time.Duration, cmd string, args ...interface{}) (interface{}, error) {
 	return timeout, nil
 }
@@ -46,9 +48,11 @@ func (tc timeoutTestConn) ReceiveContext(ctx context.Context) (interface{}, erro
 		return time.Duration(-1), nil
 	}
 }
+
 func (tc timeoutTestConn) Receive() (interface{}, error) {
 	return time.Duration(-1), nil
 }
+
 func (tc timeoutTestConn) ReceiveWithTimeout(timeout time.Duration) (interface{}, error) {
 	return timeout, nil
 }

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,5 +1,4 @@
 // Copyright 2017 Gary Burd
-
 //
 // Licensed under the Apache License, Version 2.0 (the "License"): you may
 // not use this file except in compliance with the License. You may obtain

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,4 +1,5 @@
 // Copyright 2017 Gary Burd
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License"): you may
 // not use this file except in compliance with the License. You may obtain
@@ -15,6 +16,7 @@
 package redis_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -23,6 +25,13 @@ import (
 
 type timeoutTestConn int
 
+func (tc timeoutTestConn) DoContext(ctx context.Context, cms string, args ...interface{}) (interface{}, error) {
+	if dl, ok := ctx.Deadline(); ok {
+		return time.Until(dl), nil
+	} else {
+		return time.Duration(-1), nil
+	}
+}
 func (tc timeoutTestConn) Do(string, ...interface{}) (interface{}, error) {
 	return time.Duration(-1), nil
 }
@@ -30,6 +39,13 @@ func (tc timeoutTestConn) DoWithTimeout(timeout time.Duration, cmd string, args 
 	return timeout, nil
 }
 
+func (tc timeoutTestConn) ReceiveContext(ctx context.Context) (interface{}, error) {
+	if dl, ok := ctx.Deadline(); ok {
+		return time.Until(dl), nil
+	} else {
+		return time.Duration(-1), nil
+	}
+}
 func (tc timeoutTestConn) Receive() (interface{}, error) {
 	return time.Duration(-1), nil
 }

--- a/redis/script.go
+++ b/redis/script.go
@@ -15,6 +15,7 @@
 package redis
 
 import (
+	"context"
 	"crypto/sha1"
 	"encoding/hex"
 	"io"
@@ -58,6 +59,18 @@ func (s *Script) args(spec string, keysAndArgs []interface{}) []interface{} {
 // Hash returns the script hash.
 func (s *Script) Hash() string {
 	return s.hash
+}
+
+func (s *Script) DoContext(ctx context.Context, c Conn, keysAndArgs ...interface{}) (interface{}, error) {
+	cwt, ok := c.(ConnWithContext)
+	if !ok {
+		return nil, errContextNotSupported
+	}
+	v, err := cwt.DoContext(ctx, "EVALSHA", s.args(s.hash, keysAndArgs)...)
+	if e, ok := err.(Error); ok && strings.HasPrefix(string(e), "NOSCRIPT ") {
+		v, err = cwt.DoContext(ctx, "EVAL", s.args(s.src, keysAndArgs)...)
+	}
+	return v, err
 }
 
 // Do evaluates the script. Under the covers, Do optimistically evaluates the


### PR DESCRIPTION
context is mostly used when develop a project

I think the with timeout function can also change to this rule
don't override the readtime

can this be merged and make a new tag?my project need this
by the way,can we fix the tag version number?