### PR TITLE
chore: Enable golangci-lint and fix errors

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,31 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.36
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the action will use pre-installed Go.
+          # skip-go-installation: true

--- a/redis/conn.go
+++ b/redis/conn.go
@@ -432,15 +432,23 @@ func (c *conn) writeLen(prefix byte, n int) error {
 }
 
 func (c *conn) writeString(s string) error {
-	c.writeLen('$', len(s))
-	c.bw.WriteString(s)
+	if err := c.writeLen('$', len(s)); err != nil {
+		return err
+	}
+	if _, err := c.bw.WriteString(s); err != nil {
+		return err
+	}
 	_, err := c.bw.WriteString("\r\n")
 	return err
 }
 
 func (c *conn) writeBytes(p []byte) error {
-	c.writeLen('$', len(p))
-	c.bw.Write(p)
+	if err := c.writeLen('$', len(p)); err != nil {
+		return err
+	}
+	if _, err := c.bw.Write(p); err != nil {
+		return err
+	}
 	_, err := c.bw.WriteString("\r\n")
 	return err
 }
@@ -454,7 +462,9 @@ func (c *conn) writeFloat64(n float64) error {
 }
 
 func (c *conn) writeCommand(cmd string, args []interface{}) error {
-	c.writeLen('*', 1+len(args))
+	if err := c.writeLen('*', 1+len(args)); err != nil {
+		return err
+	}
 	if err := c.writeString(cmd); err != nil {
 		return err
 	}
@@ -656,7 +666,9 @@ func (c *conn) Send(cmd string, args ...interface{}) error {
 	c.pending += 1
 	c.mu.Unlock()
 	if c.writeTimeout != 0 {
-		c.conn.SetWriteDeadline(time.Now().Add(c.writeTimeout))
+		if err := c.conn.SetWriteDeadline(time.Now().Add(c.writeTimeout)); err != nil {
+			return c.fatal(err)
+		}
 	}
 	if err := c.writeCommand(cmd, args); err != nil {
 		return c.fatal(err)
@@ -666,7 +678,9 @@ func (c *conn) Send(cmd string, args ...interface{}) error {
 
 func (c *conn) Flush() error {
 	if c.writeTimeout != 0 {
-		c.conn.SetWriteDeadline(time.Now().Add(c.writeTimeout))
+		if err := c.conn.SetWriteDeadline(time.Now().Add(c.writeTimeout)); err != nil {
+			return c.fatal(err)
+		}
 	}
 	if err := c.bw.Flush(); err != nil {
 		return c.fatal(err)
@@ -683,7 +697,9 @@ func (c *conn) ReceiveWithTimeout(timeout time.Duration) (reply interface{}, err
 	if timeout != 0 {
 		deadline = time.Now().Add(timeout)
 	}
-	c.conn.SetReadDeadline(deadline)
+	if err := c.conn.SetReadDeadline(deadline); err != nil {
+		return nil, c.fatal(err)
+	}
 
 	if reply, err = c.readReply(); err != nil {
 		return nil, c.fatal(err)
@@ -721,7 +737,9 @@ func (c *conn) DoWithTimeout(readTimeout time.Duration, cmd string, args ...inte
 	}
 
 	if c.writeTimeout != 0 {
-		c.conn.SetWriteDeadline(time.Now().Add(c.writeTimeout))
+		if err := c.conn.SetWriteDeadline(time.Now().Add(c.writeTimeout)); err != nil {
+			return nil, c.fatal(err)
+		}
 	}
 
 	if cmd != "" {
@@ -738,7 +756,9 @@ func (c *conn) DoWithTimeout(readTimeout time.Duration, cmd string, args ...inte
 	if readTimeout != 0 {
 		deadline = time.Now().Add(readTimeout)
 	}
-	c.conn.SetReadDeadline(deadline)
+	if err := c.conn.SetReadDeadline(deadline); err != nil {
+		return nil, c.fatal(err)
+	}
 
 	if cmd == "" {
 		reply := make([]interface{}, pending)

--- a/redis/log.go
+++ b/redis/log.go
@@ -52,7 +52,7 @@ func (c *loggingConn) Close() error {
 	err := c.Conn.Close()
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "%sClose() -> (%v)", c.prefix, err)
-	c.logger.Output(2, buf.String())
+	c.logger.Output(2, buf.String()) // nolint: errcheck
 	return err
 }
 
@@ -112,7 +112,7 @@ func (c *loggingConn) print(method, commandName string, args []interface{}, repl
 		buf.WriteString(", ")
 	}
 	fmt.Fprintf(&buf, "%v)", err)
-	c.logger.Output(3, buf.String())
+	c.logger.Output(3, buf.String()) // nolint: errcheck
 }
 
 func (c *loggingConn) Do(commandName string, args ...interface{}) (interface{}, error) {

--- a/redis/pool_test.go
+++ b/redis/pool_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/gomodule/redigo/redis"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -142,11 +143,13 @@ func TestPoolReuse(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		c1 := p.Get()
-		c1.Do("PING")
+		_, err := c1.Do("PING")
+		require.NoError(t, err)
 		c2 := p.Get()
-		c2.Do("PING")
-		c1.Close()
-		c2.Close()
+		_, err = c2.Do("PING")
+		require.NoError(t, err)
+		require.NoError(t, c1.Close())
+		require.NoError(t, c2.Close())
 	}
 
 	d.check("before close", p, 2, 2, 0)
@@ -164,14 +167,17 @@ func TestPoolMaxIdle(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		c1 := p.Get()
-		c1.Do("PING")
+		_, err = c1.Do("PING")
+		require.NoError(t, err)
 		c2 := p.Get()
-		c2.Do("PING")
+		_, err = c2.Do("PING")
+		require.NoError(t, err)
 		c3 := p.Get()
-		c3.Do("PING")
-		c1.Close()
-		c2.Close()
-		c3.Close()
+		_, err = c3.Do("PING")
+		require.NoError(t, err)
+		require.NoError(t, c1.Close())
+		require.NoError(t, c2.Close())
+		require.NoError(t, c3.Close())
 	}
 	d.check("before close", p, 12, 2, 0)
 	p.Close()
@@ -187,14 +193,16 @@ func TestPoolError(t *testing.T) {
 	defer p.Close()
 
 	c := p.Get()
-	c.Do("ERR", io.EOF)
+	_, err := c.Do("ERR", io.EOF)
+	require.NoError(t, err)
 	if c.Err() == nil {
 		t.Errorf("expected c.Err() != nil")
 	}
 	c.Close()
 
 	c = p.Get()
-	c.Do("ERR", io.EOF)
+	_, err = c.Do("ERR", io.EOF)
+	require.NoError(t, err)
 	c.Close()
 
 	d.check(".", p, 2, 0, 0)
@@ -209,11 +217,14 @@ func TestPoolClose(t *testing.T) {
 	defer p.Close()
 
 	c1 := p.Get()
-	c1.Do("PING")
+	_, err := c1.Do("PING")
+	require.NoError(t, err)
 	c2 := p.Get()
-	c2.Do("PING")
+	_, err = c2.Do("PING")
+	require.NoError(t, err)
 	c3 := p.Get()
-	c3.Do("PING")
+	_, err = c3.Do("PING")
+	require.NoError(t, err)
 
 	c1.Close()
 	if _, err := c1.Do("PING"); err == nil {
@@ -285,7 +296,8 @@ func TestPoolIdleTimeout(t *testing.T) {
 	defer redis.SetNowFunc(time.Now)
 
 	c := p.Get()
-	c.Do("PING")
+	_, err := c.Do("PING")
+	require.NoError(t, err)
 	c.Close()
 
 	d.check("1", p, 1, 1, 0)
@@ -293,7 +305,8 @@ func TestPoolIdleTimeout(t *testing.T) {
 	now = now.Add(p.IdleTimeout + 1)
 
 	c = p.Get()
-	c.Do("PING")
+	_, err = c.Do("PING")
+	require.NoError(t, err)
 	c.Close()
 
 	d.check("2", p, 2, 1, 0)
@@ -313,7 +326,8 @@ func TestPoolMaxLifetime(t *testing.T) {
 	defer redis.SetNowFunc(time.Now)
 
 	c := p.Get()
-	c.Do("PING")
+	_, err := c.Do("PING")
+	require.NoError(t, err)
 	c.Close()
 
 	d.check("1", p, 1, 1, 0)
@@ -321,7 +335,8 @@ func TestPoolMaxLifetime(t *testing.T) {
 	now = now.Add(p.MaxConnLifetime + 1)
 
 	c = p.Get()
-	c.Do("PING")
+	_, err = c.Do("PING")
+	require.NoError(t, err)
 	c.Close()
 
 	d.check("2", p, 2, 1, 0)
@@ -339,7 +354,7 @@ func TestPoolConcurrenSendReceive(t *testing.T) {
 		_, err := c.Receive()
 		done <- err
 	}()
-	c.Send("PING")
+	require.NoError(t, c.Send("PING"))
 	c.Flush()
 	err := <-done
 	if err != nil {
@@ -363,7 +378,8 @@ func TestPoolBorrowCheck(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		c := p.Get()
-		c.Do("PING")
+		_, err := c.Do("PING")
+		require.NoError(t, err)
 		c.Close()
 	}
 	d.check("1", p, 10, 1, 0)
@@ -379,9 +395,11 @@ func TestPoolMaxActive(t *testing.T) {
 	defer p.Close()
 
 	c1 := p.Get()
-	c1.Do("PING")
+	_, err := c1.Do("PING")
+	require.NoError(t, err)
 	c2 := p.Get()
-	c2.Do("PING")
+	_, err = c2.Do("PING")
+	require.NoError(t, err)
 
 	d.check("1", p, 2, 2, 2)
 
@@ -415,9 +433,11 @@ func TestPoolWaitStats(t *testing.T) {
 	defer p.Close()
 
 	c1 := p.Get()
-	c1.Do("PING")
+	_, err := c1.Do("PING")
+	require.NoError(t, err)
 	c2 := p.Get()
-	c2.Do("PING")
+	_, err = c2.Do("PING")
+	require.NoError(t, err)
 
 	d.checkAll("1", p, 2, 2, 2, 0, 0)
 
@@ -445,7 +465,7 @@ func TestPoolMonitorCleanup(t *testing.T) {
 	defer p.Close()
 
 	c := p.Get()
-	c.Send("MONITOR")
+	require.NoError(t, c.Send("MONITOR"))
 	c.Close()
 
 	d.check("", p, 1, 0, 0)
@@ -461,7 +481,7 @@ func TestPoolPubSubCleanup(t *testing.T) {
 	defer p.Close()
 
 	c := p.Get()
-	c.Send("SUBSCRIBE", "x")
+	require.NoError(t, c.Send("SUBSCRIBE", "x"))
 	c.Close()
 
 	want := []string{"SUBSCRIBE", "UNSUBSCRIBE", "PUNSUBSCRIBE", "ECHO"}
@@ -471,7 +491,7 @@ func TestPoolPubSubCleanup(t *testing.T) {
 	d.commands = nil
 
 	c = p.Get()
-	c.Send("PSUBSCRIBE", "x*")
+	require.NoError(t, c.Send("PSUBSCRIBE", "x*"))
 	c.Close()
 
 	want = []string{"PSUBSCRIBE", "UNSUBSCRIBE", "PUNSUBSCRIBE", "ECHO"}
@@ -491,8 +511,10 @@ func TestPoolTransactionCleanup(t *testing.T) {
 	defer p.Close()
 
 	c := p.Get()
-	c.Do("WATCH", "key")
-	c.Do("PING")
+	_, err := c.Do("WATCH", "key")
+	require.NoError(t, err)
+	_, err = c.Do("PING")
+	require.NoError(t, err)
 	c.Close()
 
 	want := []string{"WATCH", "PING", "UNWATCH"}
@@ -502,9 +524,12 @@ func TestPoolTransactionCleanup(t *testing.T) {
 	d.commands = nil
 
 	c = p.Get()
-	c.Do("WATCH", "key")
-	c.Do("UNWATCH")
-	c.Do("PING")
+	_, err = c.Do("WATCH", "key")
+	require.NoError(t, err)
+	_, err = c.Do("UNWATCH")
+	require.NoError(t, err)
+	_, err = c.Do("PING")
+	require.NoError(t, err)
 	c.Close()
 
 	want = []string{"WATCH", "UNWATCH", "PING"}
@@ -514,9 +539,12 @@ func TestPoolTransactionCleanup(t *testing.T) {
 	d.commands = nil
 
 	c = p.Get()
-	c.Do("WATCH", "key")
-	c.Do("MULTI")
-	c.Do("PING")
+	_, err = c.Do("WATCH", "key")
+	require.NoError(t, err)
+	_, err = c.Do("MULTI")
+	require.NoError(t, err)
+	_, err = c.Do("PING")
+	require.NoError(t, err)
 	c.Close()
 
 	want = []string{"WATCH", "MULTI", "PING", "DISCARD"}
@@ -526,10 +554,14 @@ func TestPoolTransactionCleanup(t *testing.T) {
 	d.commands = nil
 
 	c = p.Get()
-	c.Do("WATCH", "key")
-	c.Do("MULTI")
-	c.Do("DISCARD")
-	c.Do("PING")
+	_, err = c.Do("WATCH", "key")
+	require.NoError(t, err)
+	_, err = c.Do("MULTI")
+	require.NoError(t, err)
+	_, err = c.Do("DISCARD")
+	require.NoError(t, err)
+	_, err = c.Do("PING")
+	require.NoError(t, err)
 	c.Close()
 
 	want = []string{"WATCH", "MULTI", "DISCARD", "PING"}
@@ -539,10 +571,14 @@ func TestPoolTransactionCleanup(t *testing.T) {
 	d.commands = nil
 
 	c = p.Get()
-	c.Do("WATCH", "key")
-	c.Do("MULTI")
-	c.Do("EXEC")
-	c.Do("PING")
+	_, err = c.Do("WATCH", "key")
+	require.NoError(t, err)
+	_, err = c.Do("MULTI")
+	require.NoError(t, err)
+	_, err = c.Do("EXEC")
+	require.NoError(t, err)
+	_, err = c.Do("PING")
+	require.NoError(t, err)
 	c.Close()
 
 	want = []string{"WATCH", "MULTI", "EXEC", "PING"}

--- a/redis/pubsub.go
+++ b/redis/pubsub.go
@@ -60,27 +60,35 @@ func (c PubSubConn) Close() error {
 
 // Subscribe subscribes the connection to the specified channels.
 func (c PubSubConn) Subscribe(channel ...interface{}) error {
-	c.Conn.Send("SUBSCRIBE", channel...)
+	if err := c.Conn.Send("SUBSCRIBE", channel...); err != nil {
+		return err
+	}
 	return c.Conn.Flush()
 }
 
 // PSubscribe subscribes the connection to the given patterns.
 func (c PubSubConn) PSubscribe(channel ...interface{}) error {
-	c.Conn.Send("PSUBSCRIBE", channel...)
+	if err := c.Conn.Send("PSUBSCRIBE", channel...); err != nil {
+		return err
+	}
 	return c.Conn.Flush()
 }
 
 // Unsubscribe unsubscribes the connection from the given channels, or from all
 // of them if none is given.
 func (c PubSubConn) Unsubscribe(channel ...interface{}) error {
-	c.Conn.Send("UNSUBSCRIBE", channel...)
+	if err := c.Conn.Send("UNSUBSCRIBE", channel...); err != nil {
+		return err
+	}
 	return c.Conn.Flush()
 }
 
 // PUnsubscribe unsubscribes the connection from the given patterns, or from all
 // of them if none is given.
 func (c PubSubConn) PUnsubscribe(channel ...interface{}) error {
-	c.Conn.Send("PUNSUBSCRIBE", channel...)
+	if err := c.Conn.Send("PUNSUBSCRIBE", channel...); err != nil {
+		return err
+	}
 	return c.Conn.Flush()
 }
 
@@ -89,7 +97,9 @@ func (c PubSubConn) PUnsubscribe(channel ...interface{}) error {
 // The connection must be subscribed to at least one channel or pattern when
 // calling this method.
 func (c PubSubConn) Ping(data string) error {
-	c.Conn.Send("PING", data)
+	if err := c.Conn.Send("PING", data); err != nil {
+		return err
+	}
 	return c.Conn.Flush()
 }
 

--- a/redis/pubsub_example_test.go
+++ b/redis/pubsub_example_test.go
@@ -102,7 +102,9 @@ loop:
 	}
 
 	// Signal the receiving goroutine to exit by unsubscribing from all channels.
-	psc.Unsubscribe()
+	if err := psc.Unsubscribe(); err != nil {
+		return err
+	}
 
 	// Wait for goroutine to complete.
 	return <-done
@@ -116,9 +118,18 @@ func publish() {
 	}
 	defer c.Close()
 
-	c.Do("PUBLISH", "c1", "hello")
-	c.Do("PUBLISH", "c2", "world")
-	c.Do("PUBLISH", "c1", "goodbye")
+	if _, err = c.Do("PUBLISH", "c1", "hello"); err != nil {
+		fmt.Println(err)
+		return
+	}
+	if _, err = c.Do("PUBLISH", "c2", "world"); err != nil {
+		fmt.Println(err)
+		return
+	}
+	if _, err = c.Do("PUBLISH", "c1", "goodbye"); err != nil {
+		fmt.Println(err)
+		return
+	}
 }
 
 // This example shows how receive pubsub notifications with cancelation and

--- a/redis/reply_test.go
+++ b/redis/reply_test.go
@@ -238,8 +238,16 @@ func ExampleBool() {
 	}
 	defer c.Close()
 
-	c.Do("SET", "foo", 1)
-	exists, _ := redis.Bool(c.Do("EXISTS", "foo"))
+	if _, err = c.Do("SET", "foo", 1); err != nil {
+		fmt.Println(err)
+		return
+	}
+	exists, err := redis.Bool(c.Do("EXISTS", "foo"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
 	fmt.Printf("%#v\n", exists)
 	// Output:
 	// true
@@ -253,10 +261,22 @@ func ExampleInt() {
 	}
 	defer c.Close()
 
-	c.Do("SET", "k1", 1)
-	n, _ := redis.Int(c.Do("GET", "k1"))
+	_, err = c.Do("SET", "k1", 1)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	n, err := redis.Int(c.Do("GET", "k1"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 	fmt.Printf("%#v\n", n)
-	n, _ = redis.Int(c.Do("INCR", "k1"))
+	n, err = redis.Int(c.Do("INCR", "k1"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 	fmt.Printf("%#v\n", n)
 	// Output:
 	// 1
@@ -271,8 +291,16 @@ func ExampleInts() {
 	}
 	defer c.Close()
 
-	c.Do("SADD", "set_with_integers", 4, 5, 6)
-	ints, _ := redis.Ints(c.Do("SMEMBERS", "set_with_integers"))
+	_, err = c.Do("SADD", "set_with_integers", 4, 5, 6)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	ints, err := redis.Ints(c.Do("SMEMBERS", "set_with_integers"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 	fmt.Printf("%#v\n", ints)
 	// Output:
 	// []int{4, 5, 6}
@@ -286,8 +314,16 @@ func ExampleString() {
 	}
 	defer c.Close()
 
-	c.Do("SET", "hello", "world")
+	_, err = c.Do("SET", "hello", "world")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 	s, err := redis.String(c.Do("GET", "hello"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 	fmt.Printf("%#v\n", s)
 	// Output:
 	// "world"

--- a/redis/scan.go
+++ b/redis/scan.go
@@ -431,9 +431,8 @@ LOOP:
 }
 
 var (
-	structSpecMutex  sync.RWMutex
-	structSpecCache  = make(map[reflect.Type]*structSpec)
-	defaultFieldSpec = &fieldSpec{}
+	structSpecMutex sync.RWMutex
+	structSpecCache = make(map[reflect.Type]*structSpec)
 )
 
 func structSpecForType(t reflect.Type) *structSpec {

--- a/redis/scan_test.go
+++ b/redis/scan_test.go
@@ -115,7 +115,7 @@ func TestScanConversion(t *testing.T) {
 	for _, tt := range scanConversionTests {
 		values := []interface{}{tt.src}
 		dest := reflect.New(reflect.TypeOf(tt.dest))
-		values, err := redis.Scan(values, dest.Interface())
+		_, err := redis.Scan(values, dest.Interface())
 		if err != nil {
 			t.Errorf("Scan(%v) returned error %v", tt, err)
 			continue
@@ -144,7 +144,7 @@ func TestScanConversionError(t *testing.T) {
 	for _, tt := range scanConversionErrorTests {
 		values := []interface{}{tt.src}
 		dest := reflect.New(reflect.TypeOf(tt.dest))
-		values, err := redis.Scan(values, dest.Interface())
+		_, err := redis.Scan(values, dest.Interface())
 		if err == nil {
 			t.Errorf("Scan(%v) did not return error", tt)
 		}
@@ -159,12 +159,30 @@ func ExampleScan() {
 	}
 	defer c.Close()
 
-	c.Send("HMSET", "album:1", "title", "Red", "rating", 5)
-	c.Send("HMSET", "album:2", "title", "Earthbound", "rating", 1)
-	c.Send("HMSET", "album:3", "title", "Beat")
-	c.Send("LPUSH", "albums", "1")
-	c.Send("LPUSH", "albums", "2")
-	c.Send("LPUSH", "albums", "3")
+	if err = c.Send("HMSET", "album:1", "title", "Red", "rating", 5); err != nil {
+		fmt.Println(err)
+		return
+	}
+	if err = c.Send("HMSET", "album:2", "title", "Earthbound", "rating", 1); err != nil {
+		fmt.Println(err)
+		return
+	}
+	if err = c.Send("HMSET", "album:3", "title", "Beat"); err != nil {
+		fmt.Println(err)
+		return
+	}
+	if err = c.Send("LPUSH", "albums", "1"); err != nil {
+		fmt.Println(err)
+		return
+	}
+	if err = c.Send("LPUSH", "albums", "2"); err != nil {
+		fmt.Println(err)
+		return
+	}
+	if err = c.Send("LPUSH", "albums", "3"); err != nil {
+		fmt.Println(err)
+		return
+	}
 	values, err := redis.Values(c.Do("SORT", "albums",
 		"BY", "album:*->rating",
 		"GET", "album:*->title",
@@ -414,12 +432,30 @@ func ExampleScanSlice() {
 	}
 	defer c.Close()
 
-	c.Send("HMSET", "album:1", "title", "Red", "rating", 5)
-	c.Send("HMSET", "album:2", "title", "Earthbound", "rating", 1)
-	c.Send("HMSET", "album:3", "title", "Beat", "rating", 4)
-	c.Send("LPUSH", "albums", "1")
-	c.Send("LPUSH", "albums", "2")
-	c.Send("LPUSH", "albums", "3")
+	if err = c.Send("HMSET", "album:1", "title", "Red", "rating", 5); err != nil {
+		fmt.Println(err)
+		return
+	}
+	if err = c.Send("HMSET", "album:2", "title", "Earthbound", "rating", 1); err != nil {
+		fmt.Println(err)
+		return
+	}
+	if err = c.Send("HMSET", "album:3", "title", "Beat", "rating", 4); err != nil {
+		fmt.Println(err)
+		return
+	}
+	if err = c.Send("LPUSH", "albums", "1"); err != nil {
+		fmt.Println(err)
+		return
+	}
+	if err = c.Send("LPUSH", "albums", "2"); err != nil {
+		fmt.Println(err)
+		return
+	}
+	if err = c.Send("LPUSH", "albums", "3"); err != nil {
+		fmt.Println(err)
+		return
+	}
 	values, err := redis.Values(c.Do("SORT", "albums",
 		"BY", "album:*->rating",
 		"GET", "album:*->title",
@@ -441,8 +477,6 @@ func ExampleScanSlice() {
 	// Output:
 	// [{Earthbound 1} {Beat 4} {Red 5}]
 }
-
-var now = time.Now()
 
 type Ed struct {
 	EdI int `redis:"edi"`

--- a/redis/script.go
+++ b/redis/script.go
@@ -36,7 +36,7 @@ type Script struct {
 // SendHash methods.
 func NewScript(keyCount int, src string) *Script {
 	h := sha1.New()
-	io.WriteString(h, src)
+	io.WriteString(h, src) // nolint: errcheck
 	return &Script{keyCount, src, hex.EncodeToString(h.Sum(nil))}
 }
 

--- a/redis/script_test.go
+++ b/redis/script_test.go
@@ -78,6 +78,9 @@ func TestScript(t *testing.T) {
 	}
 
 	v, err = c.Receive()
+	if err != nil {
+		t.Errorf("s.Recieve() returned %v", err)
+	}
 	if !reflect.DeepEqual(v, reply) {
 		t.Errorf("s.SendHash(c, ..); c.Receive() = %v, want %v", v, reply)
 	}
@@ -93,6 +96,9 @@ func TestScript(t *testing.T) {
 	}
 
 	v, err = c.Receive()
+	if err != nil {
+		t.Errorf("s.Recieve() returned %v", err)
+	}
 	if !reflect.DeepEqual(v, reply) {
 		t.Errorf("s.Send(c, ..); c.Receive() = %v, want %v", v, reply)
 	}

--- a/redisx/commandinfo.go
+++ b/redisx/commandinfo.go
@@ -18,13 +18,6 @@ import (
 	"strings"
 )
 
-const (
-	connectionWatchState = 1 << iota
-	connectionMultiState
-	connectionSubscribeState
-	connectionMonitorState
-)
-
 type commandInfo struct {
 	notMuxable bool
 }

--- a/redisx/connmux.go
+++ b/redisx/connmux.go
@@ -133,7 +133,7 @@ func (c *muxConn) Close() error {
 		return nil
 	}
 	c.Flush()
-	for _ = range c.ids {
+	for range c.ids {
 		_, err = c.Receive()
 	}
 	return err

--- a/redisx/db_test.go
+++ b/redisx/db_test.go
@@ -42,7 +42,10 @@ func (t testConn) Close() error {
 // stomping on real data, DialTestDB fails if database 9 contains data. The
 // returned connection flushes database 9 on close.
 func DialTest() (redis.Conn, error) {
-	c, err := redis.DialTimeout("tcp", ":6379", 0, 1*time.Second, 1*time.Second)
+	c, err := redis.Dial("tcp", ":6379",
+		redis.DialReadTimeout(time.Second),
+		redis.DialWriteTimeout(time.Second),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Enable golangci-lint checking in travis and fix errors identified by it.