### PR TITLE
chore: Add clog config

### DIFF
--- a/.clog.toml
+++ b/.clog.toml
@@ -1,0 +1,14 @@
+[clog]
+repository = "https://github.com/gomodule/redigo"
+subtitle = "Release Notes"
+from-latest-tag = true
+
+[sections]
+"Refactors" = ["refactor"]
+"Chores" = ["chore"]
+"Continuous Integration" = ["ci"]
+"Improvements" = ["imp", "improvement"]
+"Features" = ["feat", "feature"]
+"Legacy" = ["legacy"]
+"QA" = ["qa", "test"]
+"Documentation" = ["doc", "docs"]


### PR DESCRIPTION
Add config for clog which is used for generating release notes from our conventional commits.

For details on the tool see: https://github.com/clog-tool/clog-cli