### PR TITLE
fix: DoContext call to DoWithTimeout

### DIFF
--- a/redis/conn.go
+++ b/redis/conn.go
@@ -794,7 +794,7 @@ func (c *conn) DoContext(ctx context.Context, cmd string, args ...interface{}) (
 	go func() {
 		defer close(endch)
 
-		r, e = c.DoWithTimeout(realTimeout, cmd, args)
+		r, e = c.DoWithTimeout(realTimeout, cmd, args...)
 	}()
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
Fix DoContext call to DoWithTimeout passing args as variadic.

Fixes #575