### PR TITLE
avoid inlining connection.Do

### DIFF
--- a/redis/conn.go
+++ b/redis/conn.go
@@ -770,6 +770,7 @@ func (c *conn) ReceiveWithTimeout(timeout time.Duration) (reply interface{}, err
 	return
 }
 
+//go:noinline
 func (c *conn) Do(cmd string, args ...interface{}) (interface{}, error) {
 	return c.DoWithTimeout(c.readTimeout, cmd, args...)
 }


### PR DESCRIPTION
Do method of Conn interface is inlined. Add the changes to avoid in lining Conn.DO 