### PR TITLE
fix: retract tagged versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,8 @@ module github.com/gomodule/redigo
 go 1.14
 
 require github.com/stretchr/testify v1.7.0
+
+retract (
+	v2.0.0+incompatible // Old development version not maintained or published.
+	v0.0.0-do-not-use // Never used only present due to lack of retract.
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gomodule/redigo
 
-go 1.14
+go 1.16
 
 require github.com/stretchr/testify v1.7.0
 


### PR DESCRIPTION
Retract unpublished versions from go tooling.

Also bumps go version to 1.16 as required by retract statement.

Fixes #585