### PR TITLE
fix: correct instructions for detecting DialReadTimeout

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -100,7 +100,7 @@ type ConnWithContext interface {
 	// DoContext sends a command to server and returns the received reply.
 	// min(ctx,DialReadTimeout()) will be used as the deadline.
 	// The connection will be closed if DialReadTimeout() timeout or ctx timeout or ctx canceled when this function is running.
-	// DialReadTimeout() timeout return err can be checked by strings.Contains(e.Error(), "io/timeout").
+	// DialReadTimeout() timeout return err can be checked by errors.Is(err, os.ErrDeadlineExceeded).
 	// ctx timeout return err context.DeadlineExceeded.
 	// ctx canceled return err context.Canceled.
 	DoContext(ctx context.Context, commandName string, args ...interface{}) (reply interface{}, err error)
@@ -108,7 +108,7 @@ type ConnWithContext interface {
 	// ReceiveContext receives a single reply from the Redis server.
 	// min(ctx,DialReadTimeout()) will be used as the deadline.
 	// The connection will be closed if DialReadTimeout() timeout or ctx timeout or ctx canceled when this function is running.
-	// DialReadTimeout() timeout return err can be checked by strings.Contains(e.Error(), "io/timeout").
+	// DialReadTimeout() timeout return err can be checked by errors.Is(err, os.ErrDeadlineExceeded).
 	// ctx timeout return err context.DeadlineExceeded.
 	// ctx canceled return err context.Canceled.
 	ReceiveContext(ctx context.Context) (reply interface{}, err error)
@@ -120,7 +120,7 @@ var errContextNotSupported = errors.New("redis: connection does not support Conn
 // DoContext sends a command to server and returns the received reply.
 // min(ctx,DialReadTimeout()) will be used as the deadline.
 // The connection will be closed if DialReadTimeout() timeout or ctx timeout or ctx canceled when this function is running.
-// DialReadTimeout() timeout return err can be checked by strings.Contains(e.Error(), "io/timeout").
+// DialReadTimeout() timeout return err can be checked by errors.Is(err, os.ErrDeadlineExceeded).
 // ctx timeout return err context.DeadlineExceeded.
 // ctx canceled return err context.Canceled.
 func DoContext(c Conn, ctx context.Context, cmd string, args ...interface{}) (interface{}, error) {


### PR DESCRIPTION
The actual string is "i/o timeout", but it's more clear to test error
identity in the way documented for net.Conn.

Fixes: #600