### PR TITLE
feat: add RequestContext to PubSubConn

### DIFF
--- a/redis/pubsub.go
+++ b/redis/pubsub.go
@@ -15,6 +15,7 @@
 package redis
 
 import (
+	"context"
 	"errors"
 	"time"
 )
@@ -114,6 +115,13 @@ func (c PubSubConn) Receive() interface{} {
 // override the connection's default timeout.
 func (c PubSubConn) ReceiveWithTimeout(timeout time.Duration) interface{} {
 	return c.receiveInternal(ReceiveWithTimeout(c.Conn, timeout))
+}
+
+// ReceiveContext is like Receive, but it allows termination of the receive
+// via a Context. If the call returns due to closure of the context's Done
+// channel the underlying Conn will have been closed.
+func (c PubSubConn) ReceiveContext(ctx context.Context) interface{} {
+	return c.receiveInternal(ReceiveContext(c.Conn, ctx))
 }
 
 func (c PubSubConn) receiveInternal(replyArg interface{}, errArg error) interface{} {


### PR DESCRIPTION
Add a wrapper that goes through the standard receiveInternal
processing to match the API of the existing PubSubConn Receive
methods.

Fixes: #592