### PR TITLE
chore: retract redis and redisx sub modules

### DIFF
--- a/redis/go.mod
+++ b/redis/go.mod
@@ -1,0 +1,7 @@
+module github.com/gomodule/redigo/redis
+
+go 1.16
+
+require github.com/stretchr/testify v1.7.0
+
+retract [v0.0.0-0, v0.0.1] // Never used only present to fix pkg.go.dev.

--- a/redisx/go.mod
+++ b/redisx/go.mod
@@ -1,0 +1,10 @@
+module github.com/gomodule/redigo/redisx
+
+go 1.16
+
+require (
+	github.com/gomodule/redigo v1.8.8
+	github.com/stretchr/testify v1.7.0
+)
+
+retract [v0.0.0-0, v0.0.1] // Never used only present to fix pkg.go.dev.


### PR DESCRIPTION
Retract the non versioned entries of redis and redisx modules to fix pkg.go.dev versioning.