### PR TITLE
Fixing error message for SlowLog conversion

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.36
+          version: v1.46.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/redis/reply.go
+++ b/redis/reply.go
@@ -614,13 +614,13 @@ func SlowLogs(result interface{}, err error) ([]SlowLog, error) {
 
 		timestamp, ok := rawLog[1].(int64)
 		if !ok {
-			return nil, fmt.Errorf("redigo: slowlog element[1] not an int64, got %T", rawLog[0])
+			return nil, fmt.Errorf("redigo: slowlog element[1] not an int64, got %T", rawLog[1])
 		}
 
 		log.Time = time.Unix(timestamp, 0)
 		duration, ok := rawLog[2].(int64)
 		if !ok {
-			return nil, fmt.Errorf("redigo: slowlog element[2] not an int64, got %T", rawLog[0])
+			return nil, fmt.Errorf("redigo: slowlog element[2] not an int64, got %T", rawLog[2])
 		}
 
 		log.ExecutionTime = time.Duration(duration) * time.Microsecond


### PR DESCRIPTION
Hello :wave:

I've noticed that error handling for SlowLogs parser is incorrectly references element 0. This should fix it.

Thanks