### PR TITLE
fix: update golangci-lint for golang 1.18

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.36
+          version: v1.46.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
Update golangci-lint to a version compatible with golang 1.18.