### PR TITLE
fix: respect ctx in cmds run within DialContext

### DIFF
--- a/redis/conn.go
+++ b/redis/conn.go
@@ -291,21 +291,21 @@ func DialContext(ctx context.Context, network, address string, options ...DialOp
 			authArgs = append(authArgs, do.username)
 		}
 		authArgs = append(authArgs, do.password)
-		if _, err := c.Do("AUTH", authArgs...); err != nil {
+		if _, err := c.DoContext(ctx, "AUTH", authArgs...); err != nil {
 			netConn.Close()
 			return nil, err
 		}
 	}
 
 	if do.clientName != "" {
-		if _, err := c.Do("CLIENT", "SETNAME", do.clientName); err != nil {
+		if _, err := c.DoContext(ctx, "CLIENT", "SETNAME", do.clientName); err != nil {
 			netConn.Close()
 			return nil, err
 		}
 	}
 
 	if do.db != 0 {
-		if _, err := c.Do("SELECT", do.db); err != nil {
+		if _, err := c.DoContext(ctx, "SELECT", do.db); err != nil {
 			netConn.Close()
 			return nil, err
 		}


### PR DESCRIPTION
The `DialContext()` function does not use the new `DoContext()` methods (added in v1.8.6) when configuring auth/clientName/db during connection creation. If the Redis server is unresponsive, this can cause `DialContext()` to run for a very long time (instead of cancelling when the deadline is exceeded). `DoContext` should be used for these cmds.

Repro steps:

1. Make Redis unresponsive: `CLIENT PAUSE 36000000 ALL`
2. Attempt to `DialContext()` with a 1sec timeout
3. Command is unexpectedly blocked for a long time