### PR TITLE
fix: test goroutine leaks

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - '1.17.x'
-        - '1.18.x'
+        - '1.19.x'
+        - '1.20.x'
         os:
         - 'ubuntu-latest'
         redis:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.46.2
+          version: v1.51.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/redis/reply_test.go
+++ b/redis/reply_test.go
@@ -16,7 +16,6 @@ package redis_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"math"
 	"reflect"
 	"strconv"
@@ -24,6 +23,7 @@ import (
 	"time"
 
 	"github.com/gomodule/redigo/redis"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -286,6 +286,10 @@ func TestLatencyHistories(t *testing.T) {
 		t.Skip("Latency commands not supported")
 	}
 	latencyMonitorThresholdOldCfg, err := strconv.Atoi(res[1])
+	require.NoError(t, err)
+
+	// Reset so we're compatible with -count=X
+	_, err = c.Do("LATENCY", "RESET", "command")
 	require.NoError(t, err)
 
 	// Enable latency monitoring for events that take 1ms or longer


### PR DESCRIPTION
Ensure that goroutines started by tests are cleaned up on termination.

Also make TestLatencyHistories compatible with -count=X.

Fixes #641