### PR TITLE
fix: catch array value in stringMap

### DIFF
--- a/redis/reply.go
+++ b/redis/reply.go
@@ -421,12 +421,14 @@ func StringMap(reply interface{}, err error) (map[string]string, error) {
 		func(n int) {
 			result = make(map[string]string, n)
 		}, func(key string, v interface{}) error {
-			value, ok := v.([]byte)
-			if !ok {
+			switch value := v.(type) {
+			case []byte:
+				result[key] = string(value)
+			case []interface{}:
+				return nil
+			default:
 				return fmt.Errorf("redigo: StringMap for %q not a bulk string value, got %T", key, v)
 			}
-
-			result[key] = string(value)
 
 			return nil
 		},

--- a/redis/reply_test.go
+++ b/redis/reply_test.go
@@ -426,3 +426,21 @@ func ExampleString() {
 	// Output:
 	// "world"
 }
+
+func ExampleStringMap() {
+	c, err := dial()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c.Close()
+
+	s, err := redis.StringMap(c.Do("CONFIG", "GET", "*"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Printf("%#v %#v\n", s["databases"], s["appendonly"])
+	// Output:
+	// "16" "no"
+}


### PR DESCRIPTION
Hello,

I've got the error `redigo: StringMap for "tls-allowlist" not a bulk string value, got []interface {}` using the StringMap func.

KeyDB has value-array in `CONFIG GET *` request.

What do you think, is ti possible to skip such value?
Or convert (join) array as string with `, `?

Thanks.