### PR TITLE
Run the redis test server with enable-debug-command

### DIFF
--- a/redis/test_test.go
+++ b/redis/test_test.go
@@ -78,11 +78,11 @@ func redisServerVersion() (*Version, error) {
 		return nil, fmt.Errorf("invalid major version %q", match[1])
 	}
 
-	if v.minor, err = strconv.Atoi(match[1]); err != nil {
+	if v.minor, err = strconv.Atoi(match[2]); err != nil {
 		return nil, fmt.Errorf("invalid minor version %q", match[2])
 	}
 
-	if v.patch, err = strconv.Atoi(match[1]); err != nil {
+	if v.patch, err = strconv.Atoi(match[3]); err != nil {
 		return nil, fmt.Errorf("invalid patch version %q", match[3])
 	}
 

--- a/redis/test_test.go
+++ b/redis/test_test.go
@@ -54,10 +54,10 @@ type Server struct {
 	done chan struct{}
 }
 
-type Version struct {
+type version struct {
 	major int
 	minor int
-	micro int
+	patch int
 }
 
 func GetRedisVersion() (*Version, error) {

--- a/redis/test_test.go
+++ b/redis/test_test.go
@@ -90,7 +90,7 @@ func redisServerVersion() (*Version, error) {
 }
 
 func NewServer(name string, args ...string) (*Server, error) {
-	version, err := GetRedisVersion()
+	version, err := redisServerVersion()
 	if err != nil {
 		return nil, err
 	}

--- a/redis/test_test.go
+++ b/redis/test_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -60,19 +61,19 @@ type version struct {
 	patch int
 }
 
-func redisServerVersion() (*Version, error) {
+func redisServerVersion() (*version, error) {
 	out, err := exec.Command("redis-server", "--version").Output()
 	if err != nil {
 		return nil, fmt.Errorf("server version: %w", err)
 	}
 
+	ver := string(out)
 	re := regexp.MustCompile(`v=(\d+)\.(\d+)\.(\d+)`)
 	match := re.FindStringSubmatch(ver)
 	if len(match) != 4 {
 		return nil, fmt.Errorf("no server version found in %q", ver)
 	}
 
-	var err error
 	var v version
 	if v.major, err = strconv.Atoi(match[1]); err != nil {
 		return nil, fmt.Errorf("invalid major version %q", match[1])


### PR DESCRIPTION
This is required for Redis >= 7.x, cf. https://raw.githubusercontent.com/redis/redis/7.0/00-RELEASENOTES:

```
* MODULE and DEBUG commands disabled (protected) by default, for better security (#9920)
```

Without this patch, some unit tests fail:

```
=== RUN   TestLatency
    reply_test.go:256:
                Error Trace:    /<<PKGBUILDDIR>>/_build/src/github.com/gomodule/redigo/redis/reply_test.go:256
                Error:          Received unexpected error:
                                ERR DEBUG command not allowed. If the enable-debug-command option is set to "local", you can run it from a local connection, otherwise you need to set this option in the configuration file, and then restart the server.
                Test:           TestLatency
--- FAIL: TestLatency (0.00s)
=== RUN   TestLatencyHistories
    reply_test.go:304:
                Error Trace:    /<<PKGBUILDDIR>>/_build/src/github.com/gomodule/redigo/redis/reply_test.go:304
                Error:          Received unexpected error:
                                ERR DEBUG command not allowed. If the enable-debug-command option is set to "local", you can run it from a local connection, otherwise you need to set this option in the configuration file, and then restart the server.
                Test:           TestLatencyHistories
--- FAIL: TestLatencyHistories (0.00s)
```

I tried to cook a clean patch but I'm not very familiar with Go, so it's not perfect.