### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,15 +12,15 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - '1.19.x'
-        - '1.20.x'
+        - '1.20'
+        - '1.21'
         os:
         - 'ubuntu-latest'
         redis:
+        - '7.2'
+        - '7.0'
         - '6.2'
         - '6.0'
-        - '5.0'
-        - '4.0'
     name: Test go ${{ matrix.go-version }} redis ${{ matrix.redis }} on ${{ matrix.os }}
     steps:
       - name: Setup redis
@@ -29,30 +29,12 @@ jobs:
           redis-version: ${{ matrix.redis }}
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Go Cache Paths
-        id: go-cache-paths
-        run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
-
       - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Go Build Cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-build }}
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-
-      - name: Go Mod Cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+        uses: actions/checkout@v4
 
       - name: Go Test
-        run: go test -v ./...
+        run: go test ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,21 +11,22 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup golang
+        uses: actions/setup-go@v4
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.51.2
+          go-version: '1.21'
+          cache: false # Handled by golangci-lint.
 
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
+      - name: Validate go mod
+        run: |
+          go mod tidy
+          git --no-pager diff && [[ 0 -eq $(git status --porcelain | wc -l) ]]
 
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true then the action will use pre-installed Go.
-          # skip-go-installation: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.55.2
+          args: --out-format=colored-line-number

--- a/redis/reply_test.go
+++ b/redis/reply_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -226,6 +227,17 @@ func TestSlowLog(t *testing.T) {
 	}
 }
 
+// debugCheck skips t if err indicates that DEBUG is not allowed,
+// otherwise it fails if err is not nil.
+func debugCheck(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil && strings.Contains(err.Error(), "ERR DEBUG command not allowed") {
+		t.Skip("DEBUG command not allowed")
+	}
+	require.NoError(t, err)
+}
+
 func TestLatency(t *testing.T) {
 	c, err := dial()
 	require.NoError(t, err)
@@ -253,7 +265,7 @@ func TestLatency(t *testing.T) {
 
 	// Sleep for 1ms to register a slow event.
 	_, err = c.Do("DEBUG", "SLEEP", 0.001)
-	require.NoError(t, err)
+	debugCheck(t, err)
 
 	result, err = c.Do("LATENCY", "LATEST")
 	require.NoError(t, err)
@@ -305,7 +317,7 @@ func TestLatencyHistories(t *testing.T) {
 
 	// Sleep for 1ms to register a slow event
 	_, err = c.Do("DEBUG", "SLEEP", 0.001)
-	require.NoError(t, err)
+	debugCheck(t, err)
 
 	result, err = c.Do("LATENCY", "HISTORY", "command")
 	require.NoError(t, err)


### PR DESCRIPTION
Update GitHub actions to use the latest versions and add go mod tidy check.

This bumps go version for tests to 1.20 and 1.21 the currently supported versions.