### PR TITLE
ci: add goreleaser, update action and go versions

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - '1.20'
         - '1.21'
+        - '1.22'
         os:
         - 'ubuntu-latest'
         redis:
@@ -37,4 +37,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Go Test
-        run: go test ./...
+        run: go test -race ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup golang
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false # Handled by golangci-lint.
 
       - name: Validate go mod
@@ -26,7 +26,7 @@ jobs:
           git --no-pager diff && [[ 0 -eq $(git status --porcelain | wc -l) ]]
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.55.2
+          version: v1.56.2
           args: --out-format=colored-line-number

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,32 @@
+name: Build Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: Release Go Binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,46 @@
+# When adding options check the documentation at https://goreleaser.com
+builds:
+  - skip: true
+release:
+  header: |
+    <a name='{{.Tag}}'></a>
+    ### {{.Tag}} Release Notes ({{.Date}})
+  footer: |
+    [Full Changelog](https://{{ .ModulePath }}/compare/{{ .PreviousTag }}...{{ .Tag }})
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+    - Merge pull request
+    - Merge remote-tracking branch
+    - Merge branch
+
+  # Group commits messages by given regex and title.
+  # Order value defines the order of the groups.
+  # Proving no regex means all commits will be grouped under the default group.
+  # Groups are disabled when using github-native, as it already groups things by itself.
+  # Matches are performed against strings of the form: "<abbrev-commit>[:] <title-commit>".
+  #
+  # Default is no groups.
+  groups:
+    - title: Features
+      regexp: '^.*?(feat|feature)(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: 'Bug fixes'
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: 'Chores'
+      regexp: '^.*?chore(\([[:word:]]+\))??!?:.+$'
+      order: 2
+    - title: 'Quality'
+      regexp: '^.*?(qa|test|tests)(\([[:word:]]+\))??!?:.+$'
+      order: 3
+    - title: 'Documentation'
+      regexp: '^.*?(doc|docs)(\([[:word:]]+\))??!?:.+$'
+      order: 4
+    - title: 'Continuous Integration'
+      regexp: '^.*?ci(\([[:word:]]+\))??!?:.+$'
+      order: 5
+    - title: Other
+      order: 999


### PR DESCRIPTION
Add goreleaser to automate the generation of release notes and bump the versions of github actions golang go the latest versions.