### PR TITLE
ci: remove deprecated goreleaser option

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove deprecated goreleaser option --rm-dist and use --clean instead to prevent deprecation warning.