### PR TITLE
chore: retract v1.8.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require github.com/stretchr/testify v1.8.4
 
 retract (
 	v2.0.0+incompatible // Old development version not maintained or published.
+	v1.8.10 // Incorrect version tag for feature.
 	v0.0.0-do-not-use // Never used only present due to lack of retract.
 )


### PR DESCRIPTION
Retract v1.8.10 which was tagged incorrectly for a feature release and only available for a few minutes. v1.9.0 is identical.