### PR TITLE
fix: bump go version to 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,14 @@
 module github.com/gomodule/redigo
 
-go 1.16
+go 1.17
 
 require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
 
 retract (
 	v2.0.0+incompatible // Old development version not maintained or published.


### PR DESCRIPTION
Due to our test dependency requiring 1.17 minimum and the 1.16 being well out of support, currently only 1.21 and 1.22 are support releases, bump our required go version to 1.16.

Fixes #665