### PR TITLE
fix: latency tests

### DIFF
--- a/redis/reply_test.go
+++ b/redis/reply_test.go
@@ -264,10 +264,14 @@ func TestLatency(t *testing.T) {
 	require.Equal(t, 1, len(latestLatencies))
 
 	latencyEvent := latestLatencies[0]
+
+	// The actual latency might be longer than 1ms
+	require.GreaterOrEqual(t, latencyEvent.Latest, time.Millisecond)
+	require.GreaterOrEqual(t, latencyEvent.Max, time.Millisecond)
 	expected := redis.Latency{
 		Name:   "command",
-		Latest: time.Millisecond,
-		Max:    time.Millisecond,
+		Latest: latencyEvent.Latest,
+		Max:    latencyEvent.Max,
 		Time:   latencyEvent.Time,
 	}
 	require.Equal(t, expected, latencyEvent)
@@ -315,7 +319,8 @@ func TestLatencyHistories(t *testing.T) {
 
 	require.Len(t, latencyHistory, 1)
 	latencyEvent := latencyHistory[0]
-	require.Equal(t, time.Millisecond, latencyEvent.ExecutionTime)
+	// The actual latency might be longer than 1ms
+	require.GreaterOrEqual(t, latencyEvent.ExecutionTime, time.Millisecond)
 }
 
 // dial wraps DialDefaultServer() with a more suitable function name for examples.

--- a/redis/reply_test.go
+++ b/redis/reply_test.go
@@ -270,7 +270,7 @@ func TestLatency(t *testing.T) {
 		Max:    time.Millisecond,
 		Time:   latencyEvent.Time,
 	}
-	require.Equal(t, latencyEvent, expected)
+	require.Equal(t, expected, latencyEvent)
 }
 
 func TestLatencyHistories(t *testing.T) {


### PR DESCRIPTION
Latency tests might fail on busy machines, as the actual latency is longer than expected.

Happens on the Debian build infrastructure:

- https://ci.debian.net/packages/g/golang-github-gomodule-redigo/testing/amd64/58701649/
- https://ci.debian.net/packages/g/golang-github-gomodule-redigo/testing/amd64/58700608/
- https://ci.debian.net/packages/g/golang-github-gomodule-redigo/testing/ppc64el/58700967/