### PR TITLE
fix: honor server-path in test_test.go

### DIFF
--- a/redis/test_test.go
+++ b/redis/test_test.go
@@ -63,7 +63,7 @@ type version struct {
 }
 
 func redisServerVersion() (*version, error) {
-	out, err := exec.Command("redis-server", "--version").Output()
+	out, err := exec.Command(*serverPath, "--version").Output()
 	if err != nil {
 		return nil, fmt.Errorf("server version: %w", err)
 	}


### PR DESCRIPTION
So that it's possible to run tests with:

```
go test [...] -redis-server valkey-server
```